### PR TITLE
Added Added F3 Disable Thermals component

### DIFF
--- a/f/common/functions.hpp
+++ b/f/common/functions.hpp
@@ -137,4 +137,9 @@ class F // Defines the "owner"
 		class HandleMenu{};
 		class showMenu{};
 	};
+	class disableThermals
+	{
+		file = "f\disableThermals";
+		class disableThermals {};
+	};
 };

--- a/f/disableThermals/fn_disableThermals.sqf
+++ b/f/disableThermals/fn_disableThermals.sqf
@@ -1,0 +1,35 @@
+// F3 - Disable Thermals
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+// DECLARE VARIABLES AND FUNCTIONS
+
+private ["_allowedList", "_allowedTypes", "_allowedUnits"];
+
+// SET KEY VARIABLES
+// Using the arguments passed to the script, we first define some local variables.
+
+params [["_allowedList", [], [[]]]];
+
+// INTERPRET RESTRICTED ARRAY
+// Loop through the array containing the allowed classes and units and split them into two
+
+_allowedTypes = [];
+_allowedUnits = [];
+{
+  if (_x isEqualType "") then {_allowedTypes pushBack _x};
+  if (_x isEqualType objNull) then {_allowedUnits pushBack _x};
+} forEach _allowedList;
+
+// PERFORM CHECKS
+// Check if any vehicle is one of the allowed vehicles or in the allowed types, if not, disable their thermals.
+
+{
+	private _vehicleToCheck = _x;
+
+	if (_vehicleToCheck in _allowedUnits || {{_vehicleToCheck isKindOf _x} count _allowedTypes > 0}) then {
+		// This is an allowed vehicle, ignore it
+	} else {
+		_vehicleToCheck disableTIEquipment true;
+	}
+} foreach vehicles;

--- a/init.sqf
+++ b/init.sqf
@@ -220,3 +220,8 @@ f_var_civAI = independent; 		// Optional: The civilian AI will use this side's s
 
 // INDEPENDENT > AAF
 // [INDEPENDENT,100,1] execVM "f\casualtiesCap\f_CasualtiesCapCheck.sqf";
+
+// F3 - Disable Thermals
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+[] spawn f_fnc_disableThermals;
+// [[UnitName1, "UnitClass1"]] spawn f_fnc_disableThermals;


### PR DESCRIPTION
F3 Disable Thermals component - Disables thermals on all vehicles present at the start of a mission. Has a mechanism to exempt certain vehicles or vehicle class (similar to authorised crew check).

Enabled by default.

Vehicles with thermals enabled are generally discouraged in FA missions, especially those used by players. This component inverts the responsibility of missionmakers to this end: now they must actively enable thermals where they want them, instead of actively having to remember to disable them.