### PR TITLE
Quick hotfix

### DIFF
--- a/f/nametag/include/f_nametagBrief.sqf
+++ b/f/nametag/include/f_nametagBrief.sqf
@@ -54,7 +54,9 @@
 		//<font color='#7FFFD4'>Fireteam</font><br/>
 		//<font color='#FF143C'>Vehicle Crew</font>";
 
-		//	Add brief to map screen.
-		player createDiaryRecord ["Diary", ["F3 Nametags (Options)",_bstr]];
+		
 	};
+	
+	//	Add brief to map screen.
+	player createDiaryRecord ["Diary", ["F3 Nametags (Options)",_bstr]];
 };


### PR DESCRIPTION
Accidentally made it so NO BRIEFING would show if CBA was present. This fix makes it so that a shortened briefing will show, as intended.