### PR TITLE
Issue-10: Temporary fix to prevent issues with FIA AK vehicle loadout

### DIFF
--- a/f/assignGear/f_assignGear_fiaAK_light.sqf
+++ b/f/assignGear/f_assignGear_fiaAK_light.sqf
@@ -527,6 +527,9 @@ switch (_typeofUnit) do
 		_unit addmagazines [_glmag, 3];
 		_unit addmagazines [_smokegrenade, 5];
 	};
+	
+// Redefine _carbine as an array to avoid breaking selectRandom in f_assignGear_fia_v.sqf
+_carbine = [_carbine];
 
 // Include the loadouts for vehicles and crates:
 #include "f_assignGear_fia_v.sqf";

--- a/f/assignGear/f_assignGear_fiaAK_standard.sqf
+++ b/f/assignGear/f_assignGear_fiaAK_standard.sqf
@@ -539,6 +539,9 @@ switch (_typeofUnit) do
 		_unit addmagazines [_smokegrenade, 4];
 	};
 
+// Redefine _carbine as an array to avoid breaking selectRandom in f_assignGear_fia_v.sqf
+_carbine = [_carbine];
+
 // Include the loadouts for vehicles and crates:
 #include "f_assignGear_fia_v.sqf";
 


### PR DESCRIPTION
Ref: #10 

Redefine `_carbine` as an array before the vehicle `#include` bit, to avoid breaking `selectRandom` in `f_assignGear_fia_v.sqf`.
```
_carbine = [_carbine];
```

It's perhaps a bit "hacky" instead of shifting the select random to the base gear file `f_assignGear_fiaAK.sqf`, but it does the job.