### PR TITLE
Issue 37: Dynamic View Distance Overhaul

### DIFF
--- a/f/dynamicViewDistance/f_eh_setViewDistance_onGetIn.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onGetIn.sqf
@@ -1,0 +1,22 @@
+// f_eh_setViewDistance_onGetIn.sqf
+
+private _unit = _this select 0;
+private _seatType = _this select 1; // 'driver', 'gunner', 'cargo'
+private _veh = _this select 2;
+private "_vd";
+
+if (f_var_viewDistance_crewOnly && (_seatType == 'cargo')) then
+{
+	_vd = f_var_viewDistance_default;
+	
+}
+else 
+{
+	if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
+	if (_veh isKindOf "Tank") then {_vd = f_var_viewDistance_tank;};
+	if (_veh isKindOf "Helicopter_Base_F") then {_vd = f_var_viewDistance_rotaryWing;};
+	if (_veh isKindOf "Plane") then {_vd = f_var_viewDistance_fixedWing;};
+};
+
+setViewDistance _vd;
+systemChat format ["DEBUG: Viewdistance set to %1",_vd];

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onGetIn.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onGetIn.sqf
@@ -3,19 +3,20 @@
 private _unit = _this select 0;
 private _seatType = _this select 1; // 'driver', 'gunner', 'cargo'
 private _veh = _this select 2;
-private _vd = f_var_viewDistance_default;
 
-if !(f_var_viewDistance_crewOnly && (_seatType == 'cargo')) then
+if !(f_var_viewDistance_crewOnly && {_seatType == 'cargo'}) then
 {
+	private _vd = f_var_viewDistance_default;
+	
 	if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
 	if (_veh isKindOf "Tank") then {_vd = f_var_viewDistance_tank;};
 	if (_veh isKindOf "Helicopter_Base_F") then {_vd = f_var_viewDistance_rotaryWing;};
 	if (_veh isKindOf "Plane") then {_vd = f_var_viewDistance_fixedWing;};
-};
 
-setViewDistance _vd;
-
-if (f_param_debugMode == 1) then 
-{
-	player sideChat format ["DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onGetIn.sqf): Viewdistance set to %1", viewDistance];
+	setViewDistance _vd;
+	
+	if (f_param_debugMode == 1) then 
+	{
+		player sideChat format ["DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onGetIn.sqf): Viewdistance set to %1", viewDistance];
+	};
 };

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onGetIn.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onGetIn.sqf
@@ -3,14 +3,9 @@
 private _unit = _this select 0;
 private _seatType = _this select 1; // 'driver', 'gunner', 'cargo'
 private _veh = _this select 2;
-private "_vd";
+private _vd = f_var_viewDistance_default;
 
-if (f_var_viewDistance_crewOnly && (_seatType == 'cargo')) then
-{
-	_vd = f_var_viewDistance_default;
-	
-}
-else 
+if !(f_var_viewDistance_crewOnly && (_seatType == 'cargo')) then
 {
 	if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
 	if (_veh isKindOf "Tank") then {_vd = f_var_viewDistance_tank;};
@@ -19,4 +14,8 @@ else
 };
 
 setViewDistance _vd;
-systemChat format ["DEBUG: Viewdistance set to %1",_vd];
+
+if (f_param_debugMode == 1) then 
+{
+	player sideChat format ["DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onGetIn.sqf): Viewdistance set to %1", viewDistance];
+};

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onGetIn.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onGetIn.sqf
@@ -1,11 +1,16 @@
+// FA3 - Dynamic View Distance
+// Credits: SuicideKing, Folk ARPS F3 ("FA3") Dev Team
 // f_eh_setViewDistance_onGetIn.sqf
 
+// Init defaults
 private _unit = _this select 0;
 private _seatType = _this select 1; // 'driver', 'gunner', 'cargo'
 private _veh = _this select 2;
 
+// If player is not a passenger, or if crewOnly is false, then change view distance. Otherwise no change required.
 if !(f_var_viewDistance_crewOnly && {_seatType == 'cargo'}) then
 {
+	// Set default view distance to handle edge cases like ejection seats
 	private _vd = f_var_viewDistance_default;
 	
 	if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
@@ -20,3 +25,6 @@ if !(f_var_viewDistance_crewOnly && {_seatType == 'cargo'}) then
 		player sideChat format ["DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onGetIn.sqf): Viewdistance set to %1", viewDistance];
 	};
 };
+
+// NOTE: Passenger gunner seats (like at the back of trucks) return a _seatType == 'cargo', however these units don't appear in the assignedCargo array.
+// Therefore, this script will assign them the default view distance if crewOnly is true, but SeatSwitch will assign them 'Car' viewDistance.

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onGetOut.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onGetOut.sqf
@@ -1,5 +1,8 @@
+// FA3 - Dynamic View Distance
+// Credits: SuicideKing, Folk ARPS F3 ("FA3") Dev Team
 // f_eh_setViewDistance_onGetOut.sqf
 
+// Reset viewDistance to default if it isn't already.
 if (viewDistance != f_var_viewDistance_default) then
 {
 	setViewDistance f_var_viewDistance_default;

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onGetOut.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onGetOut.sqf
@@ -1,0 +1,4 @@
+// f_eh_setViewDistance_onGetOut.sqf
+
+setViewDistance f_var_viewDistance_default;
+systemChat format ["DEBUG: Viewdistance set to %1",viewDistance];

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onGetOut.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onGetOut.sqf
@@ -1,4 +1,8 @@
 // f_eh_setViewDistance_onGetOut.sqf
 
 setViewDistance f_var_viewDistance_default;
-systemChat format ["DEBUG: Viewdistance set to %1",viewDistance];
+
+if (f_param_debugMode == 1) then 
+{
+	player sideChat format ["DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onGetOut.sqf): Viewdistance set to %1", viewDistance];
+};

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onGetOut.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onGetOut.sqf
@@ -1,8 +1,18 @@
 // f_eh_setViewDistance_onGetOut.sqf
 
-setViewDistance f_var_viewDistance_default;
-
-if (f_param_debugMode == 1) then 
+if (viewDistance != f_var_viewDistance_default) then
 {
-	player sideChat format ["DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onGetOut.sqf): Viewdistance set to %1", viewDistance];
+	setViewDistance f_var_viewDistance_default;
+
+	if (f_param_debugMode == 1) then 
+	{
+		player sideChat format ["DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onGetOut.sqf): Viewdistance set to %1", viewDistance];
+	};
+}
+else 
+{
+	if (f_param_debugMode == 1) then 
+	{
+		player sideChat "DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onGetOut.sqf): No VD change required";
+	};
 };

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onSeatChange.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onSeatChange.sqf
@@ -1,0 +1,27 @@
+// f_eh_setViewDistance_onSeatChange.sqf
+
+private _unit = _this select 0;
+private _veh = _this select 2;
+private "_vd";
+
+if (f_var_viewDistance_crewOnly && {_unit in assignedCargo _veh}) then
+{
+	_vd = f_var_viewDistance_default;
+}
+else 
+{
+	if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
+	if (_veh isKindOf "Tank") then {_vd = f_var_viewDistance_tank;};
+	if (_veh isKindOf "Helicopter_Base_F") then {_vd = f_var_viewDistance_rotaryWing;};
+	if (_veh isKindOf "Plane") then {_vd = f_var_viewDistance_fixedWing;};
+};
+
+if (_vd != viewDistance) then
+{
+	setViewDistance _vd;
+	systemChat format ["DEBUG: Viewdistance set to %1",_vd];
+}
+else
+{
+	systemChat "No VD change required";
+};

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onSeatChange.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onSeatChange.sqf
@@ -19,9 +19,16 @@ else
 if (_vd != viewDistance) then
 {
 	setViewDistance _vd;
-	systemChat format ["DEBUG: Viewdistance set to %1",_vd];
+	
+	if (f_param_debugMode == 1) then 
+	{
+		player sideChat format ["DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onSeatChange.sqf): Viewdistance set to %1",_vd];
+	};
 }
-else
+else 
 {
-	systemChat "No VD change required";
+	if (f_param_debugMode == 1) then 
+	{
+		player sideChat "DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onSeatChange.sqf): No VD change required";
+	};
 };

--- a/f/dynamicViewDistance/f_eh_setViewDistance_onSeatChange.sqf
+++ b/f/dynamicViewDistance/f_eh_setViewDistance_onSeatChange.sqf
@@ -1,21 +1,27 @@
+// FA3 - Dynamic View Distance
+// Credits: SuicideKing, Folk ARPS F3 ("FA3") Dev Team
 // f_eh_setViewDistance_onSeatChange.sqf
 
+// Init default values.
 private _unit = _this select 0;
 private _veh = _this select 2;
 private "_vd";
 
 if (f_var_viewDistance_crewOnly && {_unit in assignedCargo _veh}) then
 {
+	//If player changes to cargo seat, and crewOnly is true, set default view distance 
 	_vd = f_var_viewDistance_default;
 }
 else 
 {
+	// otherwise select appropriate view distance
 	if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
 	if (_veh isKindOf "Tank") then {_vd = f_var_viewDistance_tank;};
 	if (_veh isKindOf "Helicopter_Base_F") then {_vd = f_var_viewDistance_rotaryWing;};
 	if (_veh isKindOf "Plane") then {_vd = f_var_viewDistance_fixedWing;};
 };
 
+// if new viewDistance is different from the one in previous seat, change it, otherwise do nothing.
 if (_vd != viewDistance) then
 {
 	setViewDistance _vd;
@@ -32,3 +38,6 @@ else
 		player sideChat "DEBUG (f\dynamicViewDistance\f_eh_setViewDistance_onSeatChange.sqf): No VD change required";
 	};
 };
+
+// NOTE: Passenger gunner seats (like at the back of trucks) return a _seatType == 'cargo', however these units don't appear in the assignedCargo array.
+// Therefore, this script will assign them the 'Car' viewDistance if crewOnly is true, but GetIn will assign them default viewDistance.

--- a/f/dynamicViewDistance/f_setViewDistanceLoop.sqf
+++ b/f/dynamicViewDistance/f_setViewDistanceLoop.sqf
@@ -5,66 +5,38 @@
 // PLAYER-ONLY COMPONENT
 // No need to run this on the server
 
-if (isDedicated) exitWith {};
-
-// ====================================================================================
-
-// MAKE SURE THE PLAYER INITIALIZES PROPERLY
+if (!hasInterface) exitWith {};
 
 if (!isDedicated && (isNull player)) then
 {
     waitUntil {sleep 0.1; !isNull player};
 };
 
-// ====================================================================================
+private _unit = player;
+private _veh = vehicle player;
+private _vd = f_var_viewDistance_default;
 
-// DECLARE VARIABLES AND FUNCTIONS
-
-private ["_veh","_vd","_seat","_sleep"];
-
-// ====================================================================================
-
-// SETUP KEY VARIABLES
-// The sleep governs how often the scripts checks if the player has changed the vehicle
-
-_sleep = 3;
-
-// ====================================================================================
-
-// SET VIEW DISTANCE
-// If the player is in a cargo position, the default view distance is set. If the
-// player is in a non-cargo position within an actual vehicle, the appropriate view
-// distance is set.
-
-while {!isNull player} do {
-	_veh = vehicle player;
-	_seat = "";
-	_vd = f_var_viewDistance_default;
-
-	if (_veh != player) then {
+if (_veh != _unit) then 
+{
+	systemChat "DEBUG: Player is in a vehicle";
+	
+	if (f_var_viewDistance_crewOnly && {!(_unit in assignedCargo _veh)}) then
+	{
 		if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
 		if (_veh isKindOf "Tank") then {_vd = f_var_viewDistance_tank;};
 		if (_veh isKindOf "Helicopter_Base_F") then {_vd = f_var_viewDistance_rotaryWing;};
 		if (_veh isKindOf "Plane") then {_vd = f_var_viewDistance_fixedWing;};
-
-		_seat = (assignedVehicleRole player select 0);
-		if (_seat == "CARGO" && f_var_viewDistance_crewOnly) then {_vd = f_var_viewDistance_default;};
-	};
-
-	setViewDistance _vd;
-
-		// DEBUG
-		if (f_param_debugMode == 1) then
-		{
-			player sideChat format ["DEBUG (f\setViewDistance\f_addSetViewDistanceEHs.sqf): Viewdistance set to: = %1",_vd];
-		};
-
-	// Wait until player changes the vehicle or changes seats. Sleep 1s between every check.
-	while {_veh == vehicle player} do {
-
-		// Check if the player has changed seats.
-		if (_veh != player && {_seat != (assignedVehicleRole player select 0)}) exitWith {};
-
-		sleep _sleep;
 	};
 };
+
+setViewDistance _vd;
+systemChat format ["DEBUG: Viewdistance set to %1", viewDistance];
+
+f_ehIndex_dynamicViewDistance_0 = _unit addEventHandler ['GetInMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onGetIn.sqf'}];
+systemChat format ["DEBUG: Successfully added Event Handler ID: %1",f_ehIndex_dynamicViewDistance_0];
+
+f_ehIndex_dynamicViewDistance_1 = _unit addEventHandler ['GetOutMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onGetOut.sqf'}];
+systemChat format ["DEBUG: Successfully added Event Handler ID: %1",f_ehIndex_dynamicViewDistance_1];
+
+f_ehIndex_dynamicViewDistance_2 = _unit addEventHandler ['SeatSwitchedMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onSeatChange.sqf'}];
+systemChat format ["DEBUG: Successfully added Event Handler ID: %1",f_ehIndex_dynamicViewDistance_2];

--- a/f/dynamicViewDistance/f_setViewDistanceLoop.sqf
+++ b/f/dynamicViewDistance/f_setViewDistanceLoop.sqf
@@ -1,5 +1,6 @@
-// F3 - Dynamic View Distance
-// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// FA3 - Dynamic View Distance
+// Credits: SuicideKing, Folk ARPS F3 ("FA3") Dev Team
+// For legacy help please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 // ====================================================================================
 
 // PLAYER-ONLY COMPONENT
@@ -12,10 +13,12 @@ if (!isDedicated && (isNull player)) then
     waitUntil {sleep 0.1; !isNull player};
 };
 
+// Init default values
 private _unit = player;
 private _veh = vehicle player;
 private _vd = f_var_viewDistance_default;
 
+// If player starts in vehicle, check seats and select appropriate view distance
 if (_veh != _unit) then 
 {
 	if (f_param_debugMode == 1) then 
@@ -23,6 +26,7 @@ if (_veh != _unit) then
 		player sideChat "DEBUG (f\dynamicViewDistance\f_setViewDistanceLoop.sqf): Player starts in a vehicle";
 	};
 	
+	// If player is not a passenger, or if crewOnly is false
 	if !(f_var_viewDistance_crewOnly && {_unit in assignedCargo _veh}) then 
 	{
 		if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
@@ -32,6 +36,7 @@ if (_veh != _unit) then
 	};
 };
 
+// Apply view distance. Will be default if player is on foot, or a passenger and crewOnly is true.
 setViewDistance _vd;
 
 if (f_param_debugMode == 1) then 
@@ -39,10 +44,9 @@ if (f_param_debugMode == 1) then
 	player sideChat format ["DEBUG: Viewdistance set to %1", viewDistance];
 };
 
+// Add event handlers to player to handle GetIn, GetOut and SeatChange events.
 f_ehIndex_dynamicViewDistance_0 = _unit addEventHandler ['GetInMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onGetIn.sqf'}];
-
 f_ehIndex_dynamicViewDistance_1 = _unit addEventHandler ['GetOutMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onGetOut.sqf'}];
-
 f_ehIndex_dynamicViewDistance_2 = _unit addEventHandler ['SeatSwitchedMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onSeatChange.sqf'}];
 
 if (f_param_debugMode == 1) then 

--- a/f/dynamicViewDistance/f_setViewDistanceLoop.sqf
+++ b/f/dynamicViewDistance/f_setViewDistanceLoop.sqf
@@ -20,7 +20,7 @@ if (_veh != _unit) then
 {
 	if (f_param_debugMode == 1) then 
 	{
-		player sideChat "DEBUG (f\dynamicViewDistance\f_setViewDistanceLoop.sqf): Player is in a vehicle";
+		player sideChat "DEBUG (f\dynamicViewDistance\f_setViewDistanceLoop.sqf): Player starts in a vehicle";
 	};
 	
 	if !(f_var_viewDistance_crewOnly && {_unit in assignedCargo _veh}) then 

--- a/f/dynamicViewDistance/f_setViewDistanceLoop.sqf
+++ b/f/dynamicViewDistance/f_setViewDistanceLoop.sqf
@@ -18,9 +18,12 @@ private _vd = f_var_viewDistance_default;
 
 if (_veh != _unit) then 
 {
-	systemChat "DEBUG: Player is in a vehicle";
+	if (f_param_debugMode == 1) then 
+	{
+		player sideChat "DEBUG (f\dynamicViewDistance\f_setViewDistanceLoop.sqf): Player is in a vehicle";
+	};
 	
-	if (f_var_viewDistance_crewOnly && {!(_unit in assignedCargo _veh)}) then
+	if !(f_var_viewDistance_crewOnly && {_unit in assignedCargo _veh}) then 
 	{
 		if (_veh isKindOf "Car") then {_vd = f_var_viewDistance_car;};
 		if (_veh isKindOf "Tank") then {_vd = f_var_viewDistance_tank;};
@@ -30,13 +33,21 @@ if (_veh != _unit) then
 };
 
 setViewDistance _vd;
-systemChat format ["DEBUG: Viewdistance set to %1", viewDistance];
+
+if (f_param_debugMode == 1) then 
+{
+	player sideChat format ["DEBUG: Viewdistance set to %1", viewDistance];
+};
 
 f_ehIndex_dynamicViewDistance_0 = _unit addEventHandler ['GetInMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onGetIn.sqf'}];
-systemChat format ["DEBUG: Successfully added Event Handler ID: %1",f_ehIndex_dynamicViewDistance_0];
 
 f_ehIndex_dynamicViewDistance_1 = _unit addEventHandler ['GetOutMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onGetOut.sqf'}];
-systemChat format ["DEBUG: Successfully added Event Handler ID: %1",f_ehIndex_dynamicViewDistance_1];
 
 f_ehIndex_dynamicViewDistance_2 = _unit addEventHandler ['SeatSwitchedMan', {_this execVM 'f\dynamicViewDistance\f_eh_setViewDistance_onSeatChange.sqf'}];
-systemChat format ["DEBUG: Successfully added Event Handler ID: %1",f_ehIndex_dynamicViewDistance_2];
+
+if (f_param_debugMode == 1) then 
+{
+	player sideChat format ["DEBUG (f\dynamicViewDistance\f_setViewDistanceLoop.sqf): Successfully added Event Handler GetInMan ID: %1",f_ehIndex_dynamicViewDistance_0];
+	player sideChat format ["DEBUG (f\dynamicViewDistance\f_setViewDistanceLoop.sqf): Successfully added Event Handler GetOutMan ID: %1",f_ehIndex_dynamicViewDistance_1];
+	player sideChat format ["DEBUG (f\dynamicViewDistance\f_setViewDistanceLoop.sqf): Successfully added Event Handler SeatSwitchedMan ID: %1",f_ehIndex_dynamicViewDistance_2];
+};


### PR DESCRIPTION
Ref: #37 
Well, it's done. There's one bug which is kinda BI's fault:

> so the passenger/door gunner seats are apparently of type "cargo" according to GetInMan EH, but assignedCargo returns null 

I've added a note in the relevant files. The only negative effect is that the passenger gunners won't get the vehicle view distance (which is probably desirable) unless they switch seats. To fix this i could use assignedCargo in both places, but that would be less optimal compared to using the internal variable available to `GetInMan` - and would give door gunners the full vehicle view distance.