### PR TITLE
Issue 45: Bring back F3 pre-mount component

### DIFF
--- a/mission.sqm
+++ b/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=1099;
+		nextID=1130;
 	};
 	class Camera
 	{
@@ -56,7 +56,8 @@ addons[]=
 	"A3_Soft_F_Exp_Offroad_02",
 	"A3_Soft_F_Exp_Van_01",
 	"A3_Soft_F_Exp_Offroad_01",
-	"A3_Soft_F_Gamma_SUV_01"
+	"A3_Soft_F_Gamma_SUV_01",
+	"A3_Modules_F"
 };
 class AddonsMetaData
 {
@@ -261,7 +262,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=365;
+		items=390;
 		class Item0
 		{
 			dataType="Object";
@@ -32309,16 +32310,341 @@ class Mission
 			id=1098;
 			type="C_SUV_01_F";
 		};
+		class Item365
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={473.59708,0,776.08887};
+			};
+			name="F3_preMount_FIA";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1099;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item366
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={517.23132,0,778.17627};
+			};
+			name="F3_preMount_FIA_1";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1105;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item367
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={558.604,0,780.34607};
+			};
+			name="F3_preMount_FIA_2";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1106;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item368
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={435.57681,0,770.43823};
+			};
+			name="F3_preMount_FIA_3";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1107;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item369
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={437.03455,0,744.61487};
+			};
+			name="F3_preMount_FIA_4";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1108;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item370
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1441.297,0,786.68701};
+			};
+			name="F3_preMount_AAF";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1110;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item371
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1485.2041,0,788.32947};
+			};
+			name="F3_preMount_AAF_1";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1111;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item372
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1528.1724,0,788.09692};
+			};
+			name="F3_preMount_AAF_2";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1112;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item373
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1398.5631,0,781.28723};
+			};
+			name="F3_preMount_AAF_3";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1113;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item374
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1397.389,0,753.11096};
+			};
+			name="F3_preMount_AAF_4";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1114;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item375
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={465.21799,0,1396.6851};
+			};
+			name="F3_preMount_NATO";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1115;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item376
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={507.88394,0,1396.3147};
+			};
+			name="F3_preMount_NATO_1";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1116;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item377
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={551.10376,0,1396.1316};
+			};
+			name="F3_preMount_NATO_2";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1117;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item378
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={418.67398,0,1384.4952};
+			};
+			name="F3_preMount_NATO_3";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1118;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item379
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={415.53409,0,1358.0823};
+			};
+			name="F3_preMount_NATO_4";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1119;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item380
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1413.598,0,1409.447};
+			};
+			name="F3_preMount_SYN";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1120;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item381
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1450.3208,0,1411.637};
+			};
+			name="F3_preMount_SYN_1";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1121;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item382
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1492.4077,0,1411.3385};
+			};
+			name="F3_preMount_SYN_2";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1122;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item383
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1360.4757,0,1389.549};
+			};
+			name="F3_preMount_SYN_3";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1123;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item384
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1362.8638,0,1356.7145};
+			};
+			name="F3_preMount_SYN_4";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1124;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item385
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2417.865,0,1411.641};
+			};
+			name="F3_preMount_CSAT";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1125;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item386
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2467.3704,0,1409.2566};
+			};
+			name="F3_preMount_CSAT_1";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1126;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item387
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2523.2297,0,1408.4637};
+			};
+			name="F3_preMount_CSAT_2";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1127;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item388
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2371.0068,0,1392.3138};
+			};
+			name="F3_preMount_CSAT_3";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1128;
+			type="Logic";
+			atlOffset=185.97;
+		};
+		class Item389
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={2368.0945,0,1361.6034};
+			};
+			name="F3_preMount_CSAT_4";
+			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			id=1129;
+			type="Logic";
+			atlOffset=185.97;
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=50;
+			nextID=136;
 		};
 		class Links
 		{
-			items=50;
+			items=136;
 			class Item0
 			{
 				linkID=0;
@@ -32814,6 +33140,866 @@ class Mission
 				linkID=49;
 				item0=839;
 				item1=974;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item50
+			{
+				linkID=50;
+				item0=690;
+				item1=1099;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item51
+			{
+				linkID=51;
+				item0=54;
+				item1=1099;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item52
+			{
+				linkID=52;
+				item0=55;
+				item1=1099;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item53
+			{
+				linkID=53;
+				item0=680;
+				item1=1107;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item54
+			{
+				linkID=54;
+				item0=51;
+				item1=1107;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item55
+			{
+				linkID=55;
+				item0=707;
+				item1=1105;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item56
+			{
+				linkID=56;
+				item0=56;
+				item1=1105;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item57
+			{
+				linkID=57;
+				item0=87;
+				item1=1105;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item58
+			{
+				linkID=58;
+				item0=88;
+				item1=1106;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item59
+			{
+				linkID=59;
+				item0=89;
+				item1=1106;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item60
+			{
+				linkID=60;
+				item0=724;
+				item1=1106;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item61
+			{
+				linkID=61;
+				item0=727;
+				item1=1106;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item62
+			{
+				linkID=62;
+				item0=734;
+				item1=1106;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item63
+			{
+				linkID=63;
+				item0=52;
+				item1=1108;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item64
+			{
+				linkID=64;
+				item0=685;
+				item1=1108;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item65
+			{
+				linkID=65;
+				item0=710;
+				item1=1105;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item66
+			{
+				linkID=66;
+				item0=717;
+				item1=1105;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item67
+			{
+				linkID=67;
+				item0=693;
+				item1=1099;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item68
+			{
+				linkID=68;
+				item0=700;
+				item1=1099;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item69
+			{
+				linkID=69;
+				item0=536;
+				item1=1114;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item70
+			{
+				linkID=70;
+				item0=531;
+				item1=1113;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item71
+			{
+				linkID=71;
+				item0=545;
+				item1=1110;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item72
+			{
+				linkID=72;
+				item0=566;
+				item1=1111;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item73
+			{
+				linkID=73;
+				item0=587;
+				item1=1112;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item74
+			{
+				linkID=74;
+				item0=548;
+				item1=1110;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item75
+			{
+				linkID=75;
+				item0=555;
+				item1=1110;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item76
+			{
+				linkID=76;
+				item0=569;
+				item1=1111;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item77
+			{
+				linkID=77;
+				item0=576;
+				item1=1111;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item78
+			{
+				linkID=78;
+				item0=590;
+				item1=1112;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item79
+			{
+				linkID=79;
+				item0=597;
+				item1=1112;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item80
+			{
+				linkID=80;
+				item0=205;
+				item1=1115;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item81
+			{
+				linkID=81;
+				item0=191;
+				item1=1118;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item82
+			{
+				linkID=82;
+				item0=196;
+				item1=1119;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item83
+			{
+				linkID=83;
+				item0=59;
+				item1=1119;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item84
+			{
+				linkID=84;
+				item0=42;
+				item1=1118;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item85
+			{
+				linkID=85;
+				item0=43;
+				item1=1115;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item86
+			{
+				linkID=86;
+				item0=44;
+				item1=1116;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item87
+			{
+				linkID=87;
+				item0=45;
+				item1=1117;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item88
+			{
+				linkID=88;
+				item0=226;
+				item1=1116;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item89
+			{
+				linkID=89;
+				item0=57;
+				item1=1114;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item90
+			{
+				linkID=90;
+				item0=41;
+				item1=1113;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item91
+			{
+				linkID=91;
+				item0=38;
+				item1=1110;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item92
+			{
+				linkID=92;
+				item0=39;
+				item1=1111;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item93
+			{
+				linkID=93;
+				item0=40;
+				item1=1112;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item94
+			{
+				linkID=94;
+				item0=247;
+				item1=1117;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item95
+			{
+				linkID=95;
+				item0=250;
+				item1=1117;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item96
+			{
+				linkID=96;
+				item0=257;
+				item1=1117;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item97
+			{
+				linkID=97;
+				item0=229;
+				item1=1116;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item98
+			{
+				linkID=98;
+				item0=236;
+				item1=1116;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item99
+			{
+				linkID=99;
+				item0=208;
+				item1=1115;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item100
+			{
+				linkID=100;
+				item0=215;
+				item1=1115;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item101
+			{
+				linkID=101;
+				item0=952;
+				item1=1124;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item102
+			{
+				linkID=102;
+				item0=842;
+				item1=1124;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item103
+			{
+				linkID=103;
+				item0=951;
+				item1=1123;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item104
+			{
+				linkID=104;
+				item0=827;
+				item1=1123;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item105
+			{
+				linkID=105;
+				item0=953;
+				item1=1120;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item106
+			{
+				linkID=106;
+				item0=954;
+				item1=1120;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item107
+			{
+				linkID=107;
+				item0=855;
+				item1=1120;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item108
+			{
+				linkID=108;
+				item0=862;
+				item1=1120;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item109
+			{
+				linkID=109;
+				item0=869;
+				item1=1120;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item110
+			{
+				linkID=110;
+				item0=955;
+				item1=1121;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item111
+			{
+				linkID=111;
+				item0=956;
+				item1=1121;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item112
+			{
+				linkID=112;
+				item0=872;
+				item1=1121;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item113
+			{
+				linkID=113;
+				item0=879;
+				item1=1121;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item114
+			{
+				linkID=114;
+				item0=886;
+				item1=1121;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item115
+			{
+				linkID=115;
+				item0=957;
+				item1=1122;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item116
+			{
+				linkID=116;
+				item0=958;
+				item1=1122;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item117
+			{
+				linkID=117;
+				item0=889;
+				item1=1122;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item118
+			{
+				linkID=118;
+				item0=896;
+				item1=1122;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item119
+			{
+				linkID=119;
+				item0=903;
+				item1=1122;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item120
+			{
+				linkID=120;
+				item0=58;
+				item1=1129;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item121
+			{
+				linkID=121;
+				item0=373;
+				item1=1129;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item122
+			{
+				linkID=122;
+				item0=46;
+				item1=1128;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item123
+			{
+				linkID=123;
+				item0=368;
+				item1=1128;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item124
+			{
+				linkID=124;
+				item0=47;
+				item1=1125;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item125
+			{
+				linkID=125;
+				item0=48;
+				item1=1126;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item126
+			{
+				linkID=126;
+				item0=49;
+				item1=1127;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item127
+			{
+				linkID=127;
+				item0=424;
+				item1=1127;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item128
+			{
+				linkID=128;
+				item0=403;
+				item1=1126;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item129
+			{
+				linkID=129;
+				item0=382;
+				item1=1125;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item130
+			{
+				linkID=130;
+				item0=385;
+				item1=1125;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item131
+			{
+				linkID=131;
+				item0=392;
+				item1=1125;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item132
+			{
+				linkID=132;
+				item0=406;
+				item1=1126;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item133
+			{
+				linkID=133;
+				item0=413;
+				item1=1126;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item134
+			{
+				linkID=134;
+				item0=427;
+				item1=1127;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item135
+			{
+				linkID=135;
+				item0=434;
+				item1=1127;
 				class CustomData
 				{
 					type="Sync";


### PR DESCRIPTION
Added preMount game logics back to mission.sqm as it is seemingly no longer broken.
Changed preMount to use synchronized objects instead of group/vehicle names which was prone to error.

See also issue #45.