### PR TITLE
Continued work on issue 24

### DIFF
--- a/f/EandEcheck/f_EandECheckLoop.sqf
+++ b/f/EandEcheck/f_EandECheckLoop.sqf
@@ -56,12 +56,12 @@ if (_objects isEqualType sideUnknown) then {
 			if (_temp isEqualType grpNull) then {
 				{
 					if !(_x in _units) then {
-						_units set [count _units,_x];
+						_units pushBack _x;
 					};
 				} forEach units _temp;
 			} else {
 				if !(_x in _units) then {
-					_units set [count _units,_temp];
+					_units pushBack _temp;
 				};
 			};
 		};

--- a/f/FTMemberMarkers/f_localFTMemberMarker.sqf
+++ b/f/FTMemberMarkers/f_localFTMemberMarker.sqf
@@ -4,14 +4,15 @@
 
 // DECLARE PRIVATE VARIABLES
 
-private ["_unit","_mkrName","_mkr","_mkrBorder","_pos","_mkrborderName","_dir"];
+private ["_mkrName","_mkr","_mkrBorder","_pos","_mkrborderName","_dir"];
 
 // ====================================================================================
 
 // SET KEY VARIABLES
 // Using variables passed to the script instance, we will create some local variables:
 
-_unit = _this select 0;
+params ["_unit"];
+
 _mkrName = Format ["mkr_%1",_unit];
 _mkrborderName = Format ["mkrB_%1",_unit];
 
@@ -35,7 +36,6 @@ _mkr setMarkerTypeLocal "MIL_TRIANGLE";
 _mkr setMarkerColorLocal (_unit getvariable ["assignedTeam","ColorWhite"]);
 _mkr setMarkerSizeLocal [0.45, 0.45];
 _mkr setMarkerDirLocal (direction _unit);
-
 
 
 // ====================================================================================

--- a/f/FTMemberMarkers/fn_GetMarkerColor.sqf
+++ b/f/FTMemberMarkers/fn_GetMarkerColor.sqf
@@ -9,13 +9,15 @@
 // 		["MAIN"] call f_fnc_GetMarkerColor;
 //
 // ====================================================================================
+params [["_team", "MAIN", [""]]];
+
 private _color = "ColorWhite";
-switch ((_this select 0)) do
+switch (_team) do
 {
-  case "MAIN": {_color = "ColorWhite"};
-  case "RED": {_color = "ColorRed"};
-  case "GREEN": {_color = "ColorGreen"};
-  case "BLUE": {_color = "ColorBlue"};
-  case "YELLOW": {_color = "ColorYellow"};
+	case "MAIN": {_color = "ColorWhite"};
+	case "RED": {_color = "ColorRed"};
+	case "GREEN": {_color = "ColorGreen"};
+	case "BLUE": {_color = "ColorBlue"};
+	case "YELLOW": {_color = "ColorYellow"};
 };
 _color

--- a/f/FTMemberMarkers/fn_SetLocalFTMemberMarkers.sqf
+++ b/f/FTMemberMarkers/fn_SetLocalFTMemberMarkers.sqf
@@ -13,7 +13,7 @@
 // MAKE SURE THE PLAYER INITIALIZES PROPERLY
 if (!isDedicated && (isNull player)) then
 {
-    waitUntil {sleep 0.1; !isNull player};
+	waitUntil {sleep 0.1; !isNull player};
 };
 
 // ====================================================================================
@@ -41,13 +41,11 @@ f_fnc_SetTeamValue =
 			if(!(_x in f_var_HandlerGroup) && alive _x) then
 			{
 				[_x] execVM "f\FTMemberMarkers\f_localFTMemberMarker.sqf";
-				f_var_HandlerGroup set [count f_var_HandlerGroup,_x];
+				f_var_HandlerGroup pushBack _x;
 			};
 		} forEach units (group player);
-	sleep 5;
+		sleep 5;
 	};
-
-	//f_var_HandlerGroup = [];
 };
 
 // ====================================================================================

--- a/f/authorisedCrew/fn_authorisedCrewCheck.sqf
+++ b/f/authorisedCrew/fn_authorisedCrewCheck.sqf
@@ -4,20 +4,20 @@
 
 // DECLARE VARIABLES AND FUNCTIONS
 
-private ["_fromEH","_vehicle","_vehicleRole","_unitToCheck","_restrictedCrew","_warningMsg","_restrictcargo","_restrictedList","_restrictedTypes","_restrictedUnits"];
+private ["_warningMsg","_restrictedTypes","_restrictedUnits"];
 
 // ====================================================================================
 
 // SET KEY VARIABLES
 // Using the arguments passed to the script, we first define some local variables.
 
-_fromEH = _this select 0;
-_restrictedList= _this select 1;
-_restrictcargo = if (count _this > 2) then {_this select 2} else {false};
+params [
+	["_fromEH", [], [[]]],
+	["_restrictedList", [], [[]]],
+	["_restrictcargo", false, [false]]
+];
 
-_vehicle = _fromEH select 0;
-_vehicleRole = _fromEH select 1;
-_unitToCheck = _fromEH select 2;
+_fromEH params ["_vehicle", "_vehicleRole", "_unitToCheck"];
 
 _warningMsg = localize "STR_f_UnauthorisedCrew_Warning";
 
@@ -28,7 +28,6 @@ if (f_param_debugMode == 1) then
 	player sideChat format ["DEBUG (f\authorisedCrew\f_isAuthorisedCrew.sqf): _vehicle = %1",_vehicle];
 	player sideChat format ["DEBUG (f\authorisedCrew\f_isAuthorisedCrew.sqf): _vehicleRole = %1",_vehicleRole];
 	player sideChat format ["DEBUG (f\authorisedCrew\f_isAuthorisedCrew.sqf): _unitToCheck = %1",_unitToCheck];
-	player sideChat format ["DEBUG (f\authorisedCrew\f_isAuthorisedCrew.sqf): _restrictedCrew = %1",_restrictedCrew];
 	player sideChat format ["DEBUG (f\authorisedCrew\f_isAuthorisedCrew.sqf): _warningMsg = %1",_warningMsg];
 };
 
@@ -47,12 +46,8 @@ if (_vehicleRole == "CARGO" && !_restrictcargo) exitWith {};
 // INTERPRET RESTRICTED ARRAY
 // Loop through the array containing the allowed classes and units and split them into two
 
-_restrictedTypes = [];
-_restrictedUnits = [];
-{
-  if (_x isEqualType "") then {_restrictedTypes pushBack _x};
-  if (_x isEqualType objNull) then {_restrictedUnits pushBack _x};
-} forEach _restrictedList;
+_restrictedTypes = _restrictedList select {_x isEqualType ""};
+_restrictedUnits = _restrictedList select {_x isEqualType objNull};
 
 // ====================================================================================
 

--- a/f/briefing/f_briefing_admin.sqf
+++ b/f/briefing/f_briefing_admin.sqf
@@ -56,7 +56,6 @@ These endings are available. To trigger an ending click on its link.<br/><br/>
 ";
 
 {
-	_end = _this select 0;
 	_briefing = _briefing + format [
 	"<execute expression=""[%1] remoteExec ['f_fnc_mpEnd', 2];"">'end%1'</execute> - %2:<br/>
 	%3<br/><br/>"

--- a/f/briefing/f_loadoutNotes.sqf
+++ b/f/briefing/f_loadoutNotes.sqf
@@ -10,39 +10,32 @@ private ["_text","_weps","_items","_fnc_wepMags","_mags","_bp","_maxload","_atta
 
 // Local function to set the proper magazine count.
 _fnc_wepMags = {
-		private ["_w","_magarr","_wepMags","_magArr","_s"];
-		_w = _this select 0;
+	private ["_wepMags","_magArr","_s"];
+	params ["_w"];
 
-		//Get possible magazines for weapon
-		_wepMags = getArray (configFile >> "CfgWeapons" >> _w >> "magazines");
+	//Get possible magazines for weapon
+	_wepMags = getArray (configFile >> "CfgWeapons" >> _w >> "magazines");
 
-  		// Compare weapon magazines with player magazines
-  		_magArr = [];
-  		{
-  			// findInPairs returns the first index that matches the checked for magazine
-  			_s = [_mags,_x] call BIS_fnc_findInPairs;
+	// Compare weapon magazines with player magazines
+	_magArr = [];
+	{
+		// findInPairs returns the first index that matches the checked for magazine
+		_s = [_mags,_x] call BIS_fnc_findInPairs;
 
-  			//If we have a match
-  			if (_s != -1) then {
-  				// Add the number of magazines to the list
-  				_magArr set [count _magArr,([_mags,[_s, 1]] call BIS_fnc_returnNestedElement)];
+		//If we have a match
+		if (_s != -1) then {
+			// Add the number of magazines to the list
+			_magArr pushBack ([_mags,[_s, 1]] call BIS_fnc_returnNestedElement);
 
-  				// Remove the entry
-  				_mags = [_mags, _s] call BIS_fnc_removeIndex;
+			// Remove the entry
+			_mags deleteAt _s;
 
-  			};
-  		} forEach _wepMags;
+		};
+	} forEach _wepMags;
 
-  		if (count _magArr > 0) then {
-  			_text = _text + " [";
-
-  			{
-  				_text = _text + format ["%1",_x];
-  				if (count _magarr > (_forEachIndex + 1)) then {_text = _text + "+";}
-  			} forEach _magArr;
-
-  			_text = _text + "]";
-  		};
+	if (count _magArr > 0) then {
+		_text = _text + format ["[%1]", _magArr joinString "+"];
+	};
 };
 
 
@@ -76,9 +69,9 @@ if (count _weps > 0) then {
 		_text = _text + format["<br/>%1",getText (configFile >> "CfgWeapons" >> _x >> "displayname")];
 
 		//Add magazines for weapon
-  		[_x] call _fnc_wepMags;
+		[_x] call _fnc_wepMags;
 
-  		// Check if weapon has an underslung grenade launcher
+		// Check if weapon has an underslung grenade launcher
 		if ({_x in ["GL_3GL_F","EGLM","UGL_F"]} count (getArray (configFile >> "CfgWeapons" >> _x >> "muzzles")) > 0) then {
 			_text = _text + "<br/> |- UGL";
 			["UGL_F"] call _fnc_wepMags;
@@ -87,7 +80,7 @@ if (count _weps > 0) then {
 		// List weapon attachments
 		// Get attached items
 		_attachments = _wepItems select (([_wepItems,_x] call BIS_fnc_findNestedElement) select 0);
-		_attachments = [_attachments,0] call BIS_fnc_removeIndex; // Remove the first element as it points to the weapon itself
+		_attachments deleteAt 0; // Remove the first element as it points to the weapon itself
 
 		{
 			if (!(_x isEqualType []) && {_x != ""}) then {

--- a/f/briefing/f_orbatNotes.sqf
+++ b/f/briefing/f_orbatNotes.sqf
@@ -60,15 +60,13 @@ _groups = _groups - _hiddenGroups;
 
 _veharray = [];
 {
-
 	if ({vehicle _x != _x} count units _x > 0 ) then {
 		{
-			if (vehicle _x != _x && {!(vehicle _x in _veharray)}) then {
-			_veharray set [count _veharray,vehicle _x];
+			if (vehicle _x != _x) then {
+				_veharray pushBackUnique (vehicle _x);
 			};
 		} forEach units _x;
 	};
-
 } forEach _groups;
 
 if (count _veharray > 0) then {
@@ -112,7 +110,7 @@ _orbatText = _orbatText + "<br />VEHICLE CREWS + PASSENGERS<br />";
 
 		{
 			if (!(group _x in _groupList) && {(assignedVehicleRole _x select 0) == "CARGO"} count (units group _x) > 0) then {
-				_groupList set [count _groupList,group _x];
+				_groupList pushBack (group _x);
 			};
 		} forEach crew _x;
 

--- a/f/casualtiesCap/f_CasualtiesCapCheck.sqf
+++ b/f/casualtiesCap/f_CasualtiesCapCheck.sqf
@@ -18,28 +18,27 @@ sleep 0.1;
 
 // DECLARE PRIVATE VARIABLES
 
-private ["_grps","_pc","_end","_started","_remaining","_grpstemp","_alive","_faction","_onlyPlayers","_grp", "_Tgrp"];
+private ["_grps","_started","_remaining","_alive","_grp", "_Tgrp"];
 
 // ====================================================================================
 
 // SET KEY VARIABLES
 // Using variables passed to the script instance, we will create some local variables.
 // Up to 5 variables are passed to the script:
+// The last two variables are optional, and may not be passed to the script.
 // 0: = Side (e.g. BLUFOR), or group name(s) as string array (e.g. ["mrGroup1","myGroup2"])
 // 1: = What % of units must be dead before the ending is triggered
 // 2: = What ending will be executed. Can also be code.
-
-_grpstemp = _this select 0; // either SIDE or array with group strings
-_pc = _this select 1;
-_end = _this select 2;
-
-// SET OPTIONAL VARIABLES
-// The last two variables are optional, and may not be passed to the script.
 // 3: = If only groups with a playable leader slot will be included (default is true)
 // 4: = What faction(s) to filter for if the first variable is a side  (e.g. ["blu_f"])
 
-_onlyPlayers = if (count _this > 3) then {_this select 3} else {true};
-_faction = if (count _this > 4) then {_this select 4} else {[]};
+params [
+	["_grpstemp", sideUnknown, [sideUnknown,[]]],
+	["_pc", 100, [0]],
+	["_end", 1, [0,{}]],
+	["_onlyPlayers", true, [true]],
+	["_faction",[], [[]]]
+];
 
 // ====================================================================================
 
@@ -56,14 +55,14 @@ if(_grpstemp isEqualType sideUnknown) then // if the variable is any of the side
 		{
 			if((side _x == _grpstemp) && (leader _x in playableUnits)) then
 			{
-				_grps set [count _grps,_x]; // Add group to array
+				_grps pushBack _x; // Add group to array
 			};
 		}
 		else
 		{
 			if (side _x == _grpstemp) then
 			{
-				_grps set [count _grps,_x]; // Add group to array
+				_grps pushBack _x; // Add group to array
 			};
 		};
 
@@ -88,7 +87,7 @@ else
 		_Tgrp = call compile format ["%1",_x];
 		if(!isnil "_Tgrp") then
 		{
-			_grps set [count _grps,_Tgrp];
+			_grps pushBack _Tgrp;
 		};
 	} foreach _grpstemp;
 };
@@ -131,9 +130,9 @@ while {true} do
 
 	// Calculate how many units in the groups are still alive
 	{
-	  _grp = _x;
-	  _alive = {alive _x} count (units _grp);
-	  _remaining = _remaining + _alive;
+		_grp = _x;
+		_alive = {alive _x} count (units _grp);
+		_remaining = _remaining + _alive;
 	} forEach _grps;
 
 // DEBUG

--- a/f/common/fn_nearPlayer.sqf
+++ b/f/common/fn_nearPlayer.sqf
@@ -3,18 +3,19 @@
 // ====================================================================================
 
 // DECLARE VARIABLES AND FUNCTIONS
-private ["_distance","_pos","_players"];
-_pos = getPosATL (_this select 0);
-_distance = _this select 1;
+private ["_pos","_players"];
+
+params [
+	["_obj", objNull, [objNull]], 
+	["_distance", 0, [0]]
+];
+
+_pos = getPosATL _obj;
 
 // ====================================================================================
 
 // Create a list of all players
-_players = [];
-
-{
-   if (isPlayer _x) then {_players pushBack _x};
-} forEach playableUnits;
+_players = playableUnits select {isPlayer _x};
 
 // ====================================================================================
 

--- a/f/functions.hpp
+++ b/f/functions.hpp
@@ -64,6 +64,7 @@ class F // Defines the "owner"
 		file = "f\mapClickTeleport";
 		class mapClickTeleportUnit{};
 		class mapClickTeleportGroup{};
+		class mapClickTeleportParachute{};
 	};
 	class nametag
 	{

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -4,7 +4,7 @@
 
 // DECLARE VARIABLES AND FUNCTIONS
 
-private ["_unitfaction", "_hq", "_ft", "_sup", "_lau", "_mor", "_eng", "_ifv", "_tnk", "_rec", "_hel", "_pla", "_art", "_med", "_uav"];
+private ["_hq", "_ft", "_sup", "_lau", "_mor", "_eng", "_ifv", "_tnk", "_rec", "_hel", "_pla", "_art", "_med", "_uav"];
 
 
 // ====================================================================================
@@ -21,17 +21,9 @@ if (!isDedicated && (isNull player)) then
 // DETECT PLAYER FACTION
 // The following code detects what faction the player's slot belongs to, and stores
 // it in the private variable _unitfaction
-if(count _this == 0) then
-{
-	_unitfaction = toLower (faction player);
-
-	// If the unitfaction is different from the 	group leader's faction, the latters faction is used
-	if (_unitfaction != toLower (faction (leader group player))) then {_unitfaction = toLower (faction (leader group player))};
-}
-else
-{
-	_unitfaction = (_this select 0);
-};
+params [
+	["_unitfaction", toLower (faction (leader group player))]
+];
 
 // ====================================================================================
 

--- a/f/mapClickTeleport/fn_mapClickTeleportGroup.sqf
+++ b/f/mapClickTeleport/fn_mapClickTeleportGroup.sqf
@@ -4,14 +4,17 @@
 
 // DECLARE VARIABLES AND FUNCTIONS
 
-private ["_unit","_pos","_dispersion","_string"];
+private ["_dispersion","_string"];
 
 // ====================================================================================
 
 // SET KEY VARIABLES
 
-_unit = _this select 0;
-_pos = _this select 1;
+params [
+	"_unit",
+	["_pos", [0,0,0], [[]], 3]
+];
+
 _dispersion = 100; // The maximum dispersion for units when HALO jumping
 
 _string = if (f_var_mapClickTeleport_Height == 0) then {"Teleport"} else {"HALO"};
@@ -44,21 +47,5 @@ if (_unit == vehicle player) then {["MapClickTeleport",[f_var_mapClickTeleport_t
 // If unit is parajumping, spawn the following code to add a parachute and restore the old backpack after landing
 
 if (f_var_mapClickTeleport_Height > 0) then {
-	[_unit] spawn {
-		private ["_unit","_bp","_bpi"];
-		_unit = _this select 0;
-		_bp = backpack _unit;
-		_bpi = backPackItems _unit;
-
-		removeBackpack _unit;
-		_unit addBackpack "B_parachute";
-		waitUntil {sleep 0.1;isTouchingGround _unit;};
-		if (alive _unit) then {
-			removeBackpack _unit;
-			_unit addBackPack _bp;
-			{
-			   (unitbackpack _unit) addItemCargoGlobal [_x,1];
-			} forEach _bpi;
-		};
-	};
+	[_unit] spawn f_fnc_mapClickTeleportParachute;
 };

--- a/f/mapClickTeleport/fn_mapClickTeleportParachute.sqf
+++ b/f/mapClickTeleport/fn_mapClickTeleportParachute.sqf
@@ -1,0 +1,21 @@
+// F3 - Mission Maker Teleport
+// Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
+// ====================================================================================
+
+//add aparachute as backpack and restore the old backpack on landing
+
+private ["_bp","_bpi"];
+params ["_unit"];
+_bp = backpack _unit;
+_bpi = backPackItems _unit;
+
+removeBackpack _unit;
+_unit addBackpack "B_parachute";
+waitUntil {sleep 0.1;isTouchingGround _unit;};
+if (alive _unit) then {
+	removeBackpack _unit;
+	_unit addBackPack _bp;
+	{
+		(unitbackpack _unit) addItemCargoGlobal [_x,1];
+	} forEach _bpi;
+};

--- a/f/mapClickTeleport/fn_mapClickTeleportUnit.sqf
+++ b/f/mapClickTeleport/fn_mapClickTeleportUnit.sqf
@@ -55,21 +55,7 @@ openMap false;
 // If the players are parajumping spawn the following code to add a backpack and restore the old backpack on landing
 
 if (f_var_mapClickTeleport_Height > 0) then {
-	[player] spawn {
-		private ["_unit","_bp","_bpi"];
-		_unit = _this select 0;
-		_bp = backpack _unit;
-		_bpi = backPackItems _unit;
-
-		removeBackpack _unit;
-		_unit addBackpack "B_parachute";
-		waitUntil {sleep 0.1;isTouchingGround _unit;};
-		removeBackpack _unit;
-		_unit addBackPack _bp;
-		{
-			(unitbackpack _unit) addItemCargoGlobal [_x,1];
-		} forEach _bpi;
-	};
+	[player] spawn f_fnc_mapClickTeleportParachute;
 };
 
 // ====================================================================================

--- a/f/missionConditions/fn_SetTime.sqf
+++ b/f/missionConditions/fn_SetTime.sqf
@@ -8,14 +8,16 @@ if !(isServer) exitWith {};
 
 // DECLARE VARIABLES AND FUNCTIONS
 
-private ["_timeOfDay","_year","_month","_day","_hour","_minute","_transition","_sunsetSunrise","_sunriseSunsetExists","_sunrise","_sunset","_addTime","_time","_result","_date"];
+private ["_year","_month","_day","_hour","_minute","_transition","_sunsetSunrise","_sunriseSunsetExists","_sunrise","_sunset","_addTime","_time","_result","_date"];
 
 // ====================================================================================
 
 // SET KEY VARIABLES
 // We interpret the values parsed to the script. If the function was called from the parameters those values are used.
 
-_timeOfDay = _this select 0;
+params [
+	["_timeOfDay", 0, [0]]
+];
 
 // Exit when using mission settings
 if ( _timeOfDay == 8 ) exitWith {};

--- a/f/mpEnd/fn_mpEndReceiver.sqf
+++ b/f/mpEnd/fn_mpEndReceiver.sqf
@@ -4,10 +4,10 @@
 
 // DECLARE VARIABLES AND FUNCTIONS
 
-private ["_ending","_state"];
-
-_ending = _this select 0;
-_state = if (count _this > 1) then {_this select 1} else {true};
+params [
+	["_ending", 1, [0]],
+	["_state", true, [true]]
+];
 
 // ====================================================================================
 
@@ -116,4 +116,3 @@ if (dialog) then
 };
 
 // ====================================================================================
-

--- a/f/setGroupID/fn_setGroupID.sqf
+++ b/f/setGroupID/fn_setGroupID.sqf
@@ -5,9 +5,11 @@
 // DECLARE VARIABLES
 private ["_grp"];
 
+params ["_grp_var", "_grp_id"];
+
 // Check first if the group exists
 
-_grp = missionNamespace getVariable[(_this select 0),grpNull];
+_grp = missionNamespace getVariable[_grp_var,grpNull];
 if(!isNull _grp) then {
-	_grp setGroupId [(_this select 1),"GroupColor0"];
+	_grp setGroupId [_grp_id,"GroupColor0"];
 };


### PR DESCRIPTION
- Use `params` instead of `_this select`. 
- Use `deleteAt` instead of `BIS_fnc_removeIndex`. 
- Use `pushBack` instead of `array set [count array`.
- Extract parachute functionality in mapClickTeleport because it was duplicated across two files.