### PR TITLE
preMount: Switch back to group names as strings.

### DIFF
--- a/f/preMount/fn_mountGroups.sqf
+++ b/f/preMount/fn_mountGroups.sqf
@@ -7,48 +7,51 @@ if (!isServer) exitWith {};
 
 // ====================================================================================
 
-// DECLARE VARIABLES AND FUNCTIONS
-
-private ["_crew","_vehs","_grps","_all_grps","_fill"];
-
-// ====================================================================================
-
 // SET KEY VARIABLES
 // Using the arguments passed to the script, we first define some local variables.
 
-params [["_objects", []], ["_crew", true], ["_fill", false]];
-//_objects: Vehicles and units.
+params [
+	["_vehs", [], [[]]],
+	["_grps", [], [[]]],
+	["_crew", true, [true]],
+	["_fill", false, [false]]
+];
+
+//_vehs: Array of vehicles    (objects) 
+//_grps: Array of group names (as strings)
 //_crew: Mount into crew positions? (optional - default:true)
 //_fill: Ignore fireteam cohesion in favor of filling vehicles? (optional - default:false)
 
 // ====================================================================================
 
-// PROCESS UNITS/GROUPS
+// CLEAN THE GROUP ARRAY
 
-//Get all non-vehicle groups
-_all_grps = _objects select {_x isKindOf "CAManBase"} apply {group _x};
-//remove duplicates
-_all_grps = _all_grps arrayintersect _all_grps;
-//only take groups where at least one unit is not in a vehicle
-_grps = _all_grps select { count (units _x) > 0 && {isNull (assignedVehicle _x)} count (units _x) > 0 };
+// First we check if there are illegal groups (non-existent) in the array and remove them.
+_grps = _grps select {!isNil _x};
+// Remove duplicates
+_grps = _grps arrayintersect _grps;
+// Transform list of strings to list of groups
+_grps = _grps apply {call compile format ["%1",_x]};
+// Only take groups where at least one unit is not in a vehicle
+_grps = _grps select { count (units _x) > 0 && {isNull (assignedVehicle _x)} count (units _x) > 0 };
 
 // ====================================================================================
 
 // PROCESS VEHICLES
+// We make sure that there are only vehicles in the vehicle array
+// If a soldier-unit is in the array then we check if we can use the vehicle he's in
+{
+	if (_x isKindOf "CAManBase") then {
+		if (vehicle _x != _x) then {
+			_vehs set [_forEachIndex,vehicle _x];
+		} else {
+			_vehs = _vehs - [_x];
+		};
+	};
+} forEach _vehs;
 
-//Get all vehicles
-_vehs = _objects select {!(_x isKindOf "CAManBase")};
 //remove duplicates
 _vehs = _vehs arrayintersect _vehs;
-//Add vehicles from synced units
-{
-	{
-		private _veh = assignedVehicle _x;
-		if (!isNull _veh) then {
-			_vehs pushBackUnique _veh;
-		};
-	} forEach (units _x);
-} forEach _all_grps;
 
 // ====================================================================================
 
@@ -65,28 +68,20 @@ _vehs = _vehs arrayintersect _vehs;
 	_vehicleRoles = (typeOf _veh) call bis_fnc_vehicleRoles;	// All available roles for the vehicle
 
 	// Temporary group array
-	_grpsT = _grps;
+	_grpsT = +_grps;
 	// As long there are spare seats and groups left
 
 	while {_emptyPositions > 0 && count _grpsT > 0 && locked _veh != 2} do {
 
-		private ["_grp","_units","_run","_unit","_slot","_path"];
+		private ["_grp","_units","_unit","_slot","_path"];
 
 		_grp = _grpsT select 0;
 		_units = units _grp;
-		_run = true;
 
 		// If fireteam cohesion should be kept count the available vehicle slots, compared to the units in the group that would need a seat
 		if (!_fill && {{isNull assignedVehicle _x} count _units > _emptyPositions}) then {
-
-			_run = false;
-
-			//Remove groups that would need to be split up
-			_grpsT = _grpsT - [_grp];
-		};
-
-		if (_run) then {
-
+			//Don't process group that would need to be split up, simply remove it from the array.
+		} else {
 			// Loop through all vehicle roles and place the units in them accordingly
 			{
 				_unit = _units select 0;
@@ -112,10 +107,10 @@ _vehs = _vehs arrayintersect _vehs;
 				if (count _units == 0) exitWith {};
 
 			} forEach _vehicleRoles;
-
-			// Remove the processed group from the temporary array
-			_grpsT = _grpsT - [_grp];
 		};
+
+		// Remove the processed/skipped group from the temporary array
+		_grpsT = _grpsT - [_grp];
 
 		// Check if all units in the group have been assigned a vehicle, remove group from both group arrays
 		if ({isNull assignedVehicle _x} count (units _grp) == 0) then {_grpsT = _grpsT - [_grp];_grps = _grps - [_grp]};

--- a/mission.sqm
+++ b/mission.sqm
@@ -1045,7 +1045,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1403.2681,6.8319178,763.35657};
+				position[]={1400.7506,6.8319178,763.49799};
 			};
 			side="Empty";
 			flags=4;
@@ -1345,7 +1345,7 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1403.5269,6.8319178,734.76477};
+				position[]={1400.9404,6.8319178,734.03149};
 			};
 			side="Empty";
 			flags=4;
@@ -32356,7 +32356,7 @@ class Mission
 				position[]={473.59708,0,776.08887};
 			};
 			name="F3_preMount_FIA";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpFIA_ASL"",""GrpFIA_A1"",""GrpFIA_A2""], true, false] call f_fnc_mountGroups;";
 			id=1099;
 			type="Logic";
 			atlOffset=-5;
@@ -32369,7 +32369,7 @@ class Mission
 				position[]={517.23132,0,778.17627};
 			};
 			name="F3_preMount_FIA_1";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpFIA_BSL"",""GrpFIA_B1"",""GrpFIA_B2""], true, false] call f_fnc_mountGroups;";
 			id=1105;
 			type="Logic";
 			atlOffset=-5;
@@ -32382,7 +32382,7 @@ class Mission
 				position[]={558.604,0,780.34607};
 			};
 			name="F3_preMount_FIA_2";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpFIA_CSL"",""GrpFIA_C1"",""GrpFIA_C2""], true, false] call f_fnc_mountGroups;";
 			id=1106;
 			type="Logic";
 			atlOffset=-5;
@@ -32395,7 +32395,7 @@ class Mission
 				position[]={435.57681,0,770.43823};
 			};
 			name="F3_preMount_FIA_3";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpFIA_CO""], true, false] call f_fnc_mountGroups;";
 			id=1107;
 			type="Logic";
 			atlOffset=-5;
@@ -32408,7 +32408,7 @@ class Mission
 				position[]={437.03455,0,744.61487};
 			};
 			name="F3_preMount_FIA_4";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpFIA_DC""], true, false] call f_fnc_mountGroups;";
 			id=1108;
 			type="Logic";
 			atlOffset=-5;
@@ -32421,7 +32421,7 @@ class Mission
 				position[]={1441.297,0,786.68701};
 			};
 			name="F3_preMount_AAF";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpAAF_ASL"",""GrpAAF_A1"",""GrpAAF_A2""], true, false] call f_fnc_mountGroups;";
 			id=1110;
 			type="Logic";
 			atlOffset=-5;
@@ -32434,7 +32434,7 @@ class Mission
 				position[]={1485.2041,0,788.32947};
 			};
 			name="F3_preMount_AAF_1";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpAAF_BSL"",""GrpAAF_B1"",""GrpAAF_B2""], true, false] call f_fnc_mountGroups;;";
 			id=1111;
 			type="Logic";
 			atlOffset=-5;
@@ -32447,7 +32447,7 @@ class Mission
 				position[]={1528.1724,0,788.09692};
 			};
 			name="F3_preMount_AAF_2";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpAAF_CSL"",""GrpAAF_C1"",""GrpAAF_C2""], true, false] call f_fnc_mountGroups;";
 			id=1112;
 			type="Logic";
 			atlOffset=-5;
@@ -32460,7 +32460,7 @@ class Mission
 				position[]={1398.5631,0,781.28723};
 			};
 			name="F3_preMount_AAF_3";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpAAF_CO""], true, false] call f_fnc_mountGroups;";
 			id=1113;
 			type="Logic";
 			atlOffset=-5;
@@ -32473,7 +32473,7 @@ class Mission
 				position[]={1397.389,0,753.11096};
 			};
 			name="F3_preMount_AAF_4";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpAAF_DC""], true, false] call f_fnc_mountGroups;";
 			id=1114;
 			type="Logic";
 			atlOffset=-5;
@@ -32486,7 +32486,7 @@ class Mission
 				position[]={465.21799,0,1396.6851};
 			};
 			name="F3_preMount_NATO";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpNATO_ASL"",""GrpNATO_A1"",""GrpNATO_A2""], true, false] call f_fnc_mountGroups;";
 			id=1115;
 			type="Logic";
 			atlOffset=-5;
@@ -32499,7 +32499,7 @@ class Mission
 				position[]={507.88394,0,1396.3147};
 			};
 			name="F3_preMount_NATO_1";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpNATO_BSL"",""GrpNATO_B1"",""GrpNATO_B2""], true, false] call f_fnc_mountGroups;";
 			id=1116;
 			type="Logic";
 			atlOffset=-5;
@@ -32512,7 +32512,7 @@ class Mission
 				position[]={551.10376,0,1396.1316};
 			};
 			name="F3_preMount_NATO_2";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpNATO_CSL"",""GrpNATO_C1"",""GrpNATO_C2""], true, false] call f_fnc_mountGroups;";
 			id=1117;
 			type="Logic";
 			atlOffset=-5;
@@ -32525,7 +32525,7 @@ class Mission
 				position[]={418.67398,0,1384.4952};
 			};
 			name="F3_preMount_NATO_3";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpNATO_CO""], true, false] call f_fnc_mountGroups;";
 			id=1118;
 			type="Logic";
 			atlOffset=-5;
@@ -32538,7 +32538,7 @@ class Mission
 				position[]={415.53409,0,1358.0823};
 			};
 			name="F3_preMount_NATO_4";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpNATO_DC""], true, false] call f_fnc_mountGroups;";
 			id=1119;
 			type="Logic";
 			atlOffset=-5;
@@ -32551,7 +32551,7 @@ class Mission
 				position[]={1413.598,0,1409.447};
 			};
 			name="F3_preMount_SYN";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpSYN_ASL"",""GrpSYN_A1"",""GrpSYN_A2""], true, false] call f_fnc_mountGroups;";
 			id=1120;
 			type="Logic";
 			atlOffset=-5;
@@ -32564,7 +32564,7 @@ class Mission
 				position[]={1450.3208,0,1411.637};
 			};
 			name="F3_preMount_SYN_1";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpSYN_BSL"",""GrpSYN_B1"",""GrpSYN_B2""], true, false] call f_fnc_mountGroups;";
 			id=1121;
 			type="Logic";
 			atlOffset=-5;
@@ -32577,7 +32577,7 @@ class Mission
 				position[]={1492.4077,0,1411.3385};
 			};
 			name="F3_preMount_SYN_2";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpSYN_CSL"",""GrpSYN_C1"",""GrpSYN_C2""], true, false] call f_fnc_mountGroups;";
 			id=1122;
 			type="Logic";
 			atlOffset=-5;
@@ -32590,7 +32590,7 @@ class Mission
 				position[]={1360.4757,0,1389.549};
 			};
 			name="F3_preMount_SYN_3";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpSYN_CO""], true, false] call f_fnc_mountGroups;";
 			id=1123;
 			type="Logic";
 			atlOffset=-5;
@@ -32603,7 +32603,7 @@ class Mission
 				position[]={1362.8638,0,1356.7145};
 			};
 			name="F3_preMount_SYN_4";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpSYN_DC""], true, false] call f_fnc_mountGroups;";
 			id=1124;
 			type="Logic";
 			atlOffset=-5;
@@ -32616,7 +32616,7 @@ class Mission
 				position[]={2417.865,0,1411.641};
 			};
 			name="F3_preMount_CSAT";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpCSAT_ASL"",""GrpCSAT_A1"",""GrpCSAT_A2""], true, false] call f_fnc_mountGroups;";
 			id=1125;
 			type="Logic";
 			atlOffset=-5;
@@ -32629,7 +32629,7 @@ class Mission
 				position[]={2467.3704,0,1409.2566};
 			};
 			name="F3_preMount_CSAT_1";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpCSAT_BSL"",""GrpCSAT_B1"",""GrpCSAT_B2""], true, false] call f_fnc_mountGroups;";
 			id=1126;
 			type="Logic";
 			atlOffset=-5;
@@ -32642,7 +32642,7 @@ class Mission
 				position[]={2523.2297,0,1408.4637};
 			};
 			name="F3_preMount_CSAT_2";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpCSAT_CSL"",""GrpCSAT_C1"",""GrpCSAT_C2""], true, false] call f_fnc_mountGroups;";
 			id=1127;
 			type="Logic";
 			atlOffset=-5;
@@ -32655,7 +32655,7 @@ class Mission
 				position[]={2371.0068,0,1392.3138};
 			};
 			name="F3_preMount_CSAT_3";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpCSAT_CO""], true, false] call f_fnc_mountGroups;";
 			id=1128;
 			type="Logic";
 			atlOffset=-5;
@@ -32668,7 +32668,7 @@ class Mission
 				position[]={2368.0945,0,1361.6034};
 			};
 			name="F3_preMount_CSAT_4";
-			init="[synchronizedObjects this,true,false] call f_fnc_mountGroups;";
+			init="[synchronizedObjects this, [""GrpCSAT_DC""], true, false] call f_fnc_mountGroups;";
 			id=1129;
 			type="Logic";
 			atlOffset=-5;
@@ -33122,11 +33122,11 @@ class Mission
 	{
 		class LinkIDProvider
 		{
-			nextID=136;
+			nextID=81;
 		};
 		class Links
 		{
-			items=136;
+			items=81;
 			class Item0
 			{
 				linkID=0;
@@ -33630,7 +33630,7 @@ class Mission
 			class Item50
 			{
 				linkID=50;
-				item0=690;
+				item0=54;
 				item1=1099;
 				class CustomData
 				{
@@ -33640,7 +33640,7 @@ class Mission
 			class Item51
 			{
 				linkID=51;
-				item0=54;
+				item0=55;
 				item1=1099;
 				class CustomData
 				{
@@ -33650,8 +33650,8 @@ class Mission
 			class Item52
 			{
 				linkID=52;
-				item0=55;
-				item1=1099;
+				item0=51;
+				item1=1107;
 				class CustomData
 				{
 					type="Sync";
@@ -33660,8 +33660,8 @@ class Mission
 			class Item53
 			{
 				linkID=53;
-				item0=680;
-				item1=1107;
+				item0=56;
+				item1=1105;
 				class CustomData
 				{
 					type="Sync";
@@ -33670,8 +33670,8 @@ class Mission
 			class Item54
 			{
 				linkID=54;
-				item0=51;
-				item1=1107;
+				item0=87;
+				item1=1105;
 				class CustomData
 				{
 					type="Sync";
@@ -33680,8 +33680,8 @@ class Mission
 			class Item55
 			{
 				linkID=55;
-				item0=707;
-				item1=1105;
+				item0=88;
+				item1=1106;
 				class CustomData
 				{
 					type="Sync";
@@ -33690,8 +33690,8 @@ class Mission
 			class Item56
 			{
 				linkID=56;
-				item0=56;
-				item1=1105;
+				item0=89;
+				item1=1106;
 				class CustomData
 				{
 					type="Sync";
@@ -33700,8 +33700,8 @@ class Mission
 			class Item57
 			{
 				linkID=57;
-				item0=87;
-				item1=1105;
+				item0=52;
+				item1=1108;
 				class CustomData
 				{
 					type="Sync";
@@ -33710,8 +33710,8 @@ class Mission
 			class Item58
 			{
 				linkID=58;
-				item0=88;
-				item1=1106;
+				item0=59;
+				item1=1119;
 				class CustomData
 				{
 					type="Sync";
@@ -33720,8 +33720,8 @@ class Mission
 			class Item59
 			{
 				linkID=59;
-				item0=89;
-				item1=1106;
+				item0=42;
+				item1=1118;
 				class CustomData
 				{
 					type="Sync";
@@ -33730,8 +33730,8 @@ class Mission
 			class Item60
 			{
 				linkID=60;
-				item0=724;
-				item1=1106;
+				item0=43;
+				item1=1115;
 				class CustomData
 				{
 					type="Sync";
@@ -33740,8 +33740,8 @@ class Mission
 			class Item61
 			{
 				linkID=61;
-				item0=727;
-				item1=1106;
+				item0=44;
+				item1=1116;
 				class CustomData
 				{
 					type="Sync";
@@ -33750,8 +33750,8 @@ class Mission
 			class Item62
 			{
 				linkID=62;
-				item0=734;
-				item1=1106;
+				item0=45;
+				item1=1117;
 				class CustomData
 				{
 					type="Sync";
@@ -33760,8 +33760,8 @@ class Mission
 			class Item63
 			{
 				linkID=63;
-				item0=52;
-				item1=1108;
+				item0=57;
+				item1=1114;
 				class CustomData
 				{
 					type="Sync";
@@ -33770,8 +33770,8 @@ class Mission
 			class Item64
 			{
 				linkID=64;
-				item0=685;
-				item1=1108;
+				item0=41;
+				item1=1113;
 				class CustomData
 				{
 					type="Sync";
@@ -33780,8 +33780,8 @@ class Mission
 			class Item65
 			{
 				linkID=65;
-				item0=710;
-				item1=1105;
+				item0=38;
+				item1=1110;
 				class CustomData
 				{
 					type="Sync";
@@ -33790,8 +33790,8 @@ class Mission
 			class Item66
 			{
 				linkID=66;
-				item0=717;
-				item1=1105;
+				item0=39;
+				item1=1111;
 				class CustomData
 				{
 					type="Sync";
@@ -33800,8 +33800,8 @@ class Mission
 			class Item67
 			{
 				linkID=67;
-				item0=693;
-				item1=1099;
+				item0=40;
+				item1=1112;
 				class CustomData
 				{
 					type="Sync";
@@ -33810,8 +33810,8 @@ class Mission
 			class Item68
 			{
 				linkID=68;
-				item0=700;
-				item1=1099;
+				item0=952;
+				item1=1124;
 				class CustomData
 				{
 					type="Sync";
@@ -33820,8 +33820,8 @@ class Mission
 			class Item69
 			{
 				linkID=69;
-				item0=536;
-				item1=1114;
+				item0=951;
+				item1=1123;
 				class CustomData
 				{
 					type="Sync";
@@ -33830,8 +33830,8 @@ class Mission
 			class Item70
 			{
 				linkID=70;
-				item0=531;
-				item1=1113;
+				item0=953;
+				item1=1120;
 				class CustomData
 				{
 					type="Sync";
@@ -33840,8 +33840,8 @@ class Mission
 			class Item71
 			{
 				linkID=71;
-				item0=545;
-				item1=1110;
+				item0=954;
+				item1=1120;
 				class CustomData
 				{
 					type="Sync";
@@ -33850,8 +33850,8 @@ class Mission
 			class Item72
 			{
 				linkID=72;
-				item0=566;
-				item1=1111;
+				item0=955;
+				item1=1121;
 				class CustomData
 				{
 					type="Sync";
@@ -33860,8 +33860,8 @@ class Mission
 			class Item73
 			{
 				linkID=73;
-				item0=587;
-				item1=1112;
+				item0=956;
+				item1=1121;
 				class CustomData
 				{
 					type="Sync";
@@ -33870,8 +33870,8 @@ class Mission
 			class Item74
 			{
 				linkID=74;
-				item0=548;
-				item1=1110;
+				item0=957;
+				item1=1122;
 				class CustomData
 				{
 					type="Sync";
@@ -33880,8 +33880,8 @@ class Mission
 			class Item75
 			{
 				linkID=75;
-				item0=555;
-				item1=1110;
+				item0=958;
+				item1=1122;
 				class CustomData
 				{
 					type="Sync";
@@ -33890,8 +33890,8 @@ class Mission
 			class Item76
 			{
 				linkID=76;
-				item0=569;
-				item1=1111;
+				item0=58;
+				item1=1129;
 				class CustomData
 				{
 					type="Sync";
@@ -33900,8 +33900,8 @@ class Mission
 			class Item77
 			{
 				linkID=77;
-				item0=576;
-				item1=1111;
+				item0=46;
+				item1=1128;
 				class CustomData
 				{
 					type="Sync";
@@ -33910,8 +33910,8 @@ class Mission
 			class Item78
 			{
 				linkID=78;
-				item0=590;
-				item1=1112;
+				item0=47;
+				item1=1125;
 				class CustomData
 				{
 					type="Sync";
@@ -33920,8 +33920,8 @@ class Mission
 			class Item79
 			{
 				linkID=79;
-				item0=597;
-				item1=1112;
+				item0=48;
+				item1=1126;
 				class CustomData
 				{
 					type="Sync";
@@ -33930,557 +33930,7 @@ class Mission
 			class Item80
 			{
 				linkID=80;
-				item0=205;
-				item1=1115;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item81
-			{
-				linkID=81;
-				item0=191;
-				item1=1118;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item82
-			{
-				linkID=82;
-				item0=196;
-				item1=1119;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item83
-			{
-				linkID=83;
-				item0=59;
-				item1=1119;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item84
-			{
-				linkID=84;
-				item0=42;
-				item1=1118;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item85
-			{
-				linkID=85;
-				item0=43;
-				item1=1115;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item86
-			{
-				linkID=86;
-				item0=44;
-				item1=1116;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item87
-			{
-				linkID=87;
-				item0=45;
-				item1=1117;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item88
-			{
-				linkID=88;
-				item0=226;
-				item1=1116;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item89
-			{
-				linkID=89;
-				item0=57;
-				item1=1114;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item90
-			{
-				linkID=90;
-				item0=41;
-				item1=1113;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item91
-			{
-				linkID=91;
-				item0=38;
-				item1=1110;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item92
-			{
-				linkID=92;
-				item0=39;
-				item1=1111;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item93
-			{
-				linkID=93;
-				item0=40;
-				item1=1112;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item94
-			{
-				linkID=94;
-				item0=247;
-				item1=1117;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item95
-			{
-				linkID=95;
-				item0=250;
-				item1=1117;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item96
-			{
-				linkID=96;
-				item0=257;
-				item1=1117;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item97
-			{
-				linkID=97;
-				item0=229;
-				item1=1116;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item98
-			{
-				linkID=98;
-				item0=236;
-				item1=1116;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item99
-			{
-				linkID=99;
-				item0=208;
-				item1=1115;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item100
-			{
-				linkID=100;
-				item0=215;
-				item1=1115;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item101
-			{
-				linkID=101;
-				item0=952;
-				item1=1124;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item102
-			{
-				linkID=102;
-				item0=842;
-				item1=1124;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item103
-			{
-				linkID=103;
-				item0=951;
-				item1=1123;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item104
-			{
-				linkID=104;
-				item0=827;
-				item1=1123;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item105
-			{
-				linkID=105;
-				item0=953;
-				item1=1120;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item106
-			{
-				linkID=106;
-				item0=954;
-				item1=1120;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item107
-			{
-				linkID=107;
-				item0=855;
-				item1=1120;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item108
-			{
-				linkID=108;
-				item0=862;
-				item1=1120;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item109
-			{
-				linkID=109;
-				item0=869;
-				item1=1120;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item110
-			{
-				linkID=110;
-				item0=955;
-				item1=1121;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item111
-			{
-				linkID=111;
-				item0=956;
-				item1=1121;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item112
-			{
-				linkID=112;
-				item0=872;
-				item1=1121;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item113
-			{
-				linkID=113;
-				item0=879;
-				item1=1121;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item114
-			{
-				linkID=114;
-				item0=886;
-				item1=1121;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item115
-			{
-				linkID=115;
-				item0=957;
-				item1=1122;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item116
-			{
-				linkID=116;
-				item0=958;
-				item1=1122;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item117
-			{
-				linkID=117;
-				item0=889;
-				item1=1122;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item118
-			{
-				linkID=118;
-				item0=896;
-				item1=1122;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item119
-			{
-				linkID=119;
-				item0=903;
-				item1=1122;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item120
-			{
-				linkID=120;
-				item0=58;
-				item1=1129;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item121
-			{
-				linkID=121;
-				item0=373;
-				item1=1129;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item122
-			{
-				linkID=122;
-				item0=46;
-				item1=1128;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item123
-			{
-				linkID=123;
-				item0=368;
-				item1=1128;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item124
-			{
-				linkID=124;
-				item0=47;
-				item1=1125;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item125
-			{
-				linkID=125;
-				item0=48;
-				item1=1126;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item126
-			{
-				linkID=126;
 				item0=49;
-				item1=1127;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item127
-			{
-				linkID=127;
-				item0=424;
-				item1=1127;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item128
-			{
-				linkID=128;
-				item0=403;
-				item1=1126;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item129
-			{
-				linkID=129;
-				item0=382;
-				item1=1125;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item130
-			{
-				linkID=130;
-				item0=385;
-				item1=1125;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item131
-			{
-				linkID=131;
-				item0=392;
-				item1=1125;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item132
-			{
-				linkID=132;
-				item0=406;
-				item1=1126;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item133
-			{
-				linkID=133;
-				item0=413;
-				item1=1126;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item134
-			{
-				linkID=134;
-				item0=427;
-				item1=1127;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item135
-			{
-				linkID=135;
-				item0=434;
 				item1=1127;
 				class CustomData
 				{


### PR DESCRIPTION
Revert to string arrays instead of group names, because if a synced unit was not slotted, then the whole group would not have been mounted.

Related to issue #45 and pull request #97.