### PR TITLE
Issue 152: don't run nametag and FTMemberMarkers for virtual entities

### DIFF
--- a/f/FTMemberMarkers/fn_SetLocalFTMemberMarkers.sqf
+++ b/f/FTMemberMarkers/fn_SetLocalFTMemberMarkers.sqf
@@ -16,6 +16,9 @@ if (!isDedicated && (isNull player)) then
 	waitUntil {sleep 0.1; !isNull player};
 };
 
+// Don't run this for zeus and virtual spectators
+if (side player isEqualto sideLogic) exitWith {};
+
 // ====================================================================================
 
 // DEFINE HELPER-FUNCTION

--- a/f/nametag/f_nametagInit.sqf
+++ b/f/nametag/f_nametagInit.sqf
@@ -15,7 +15,7 @@
 if (!hasInterface) exitWith {};
 
 //	Global variable that will be flipped on and off using the disableKey and CBA.
-F_NT_NAMETAGS_ON = true; 
+F_NT_NAMETAGS_ON = true;
 
 //	Determine which mods are active.
 #include "include\f_nametagCheckMods.sqf";
@@ -39,6 +39,9 @@ F_NT_NAMETAGS_ON = true;
 //	Let the player initialize properly.
 waitUntil{!isNull player};
 waitUntil{player == player};
+
+// Don't run this for zeus and virtual spectators
+if (side player isEqualto sideLogic) exitWith {};
 
 //	Reset font spacing and size to (possibly) new conditions.
 call f_fnc_nametagResetFont;
@@ -66,8 +69,8 @@ waitUntil {!isNull (findDisplay 46)};
 //	Render nametags from the cache every frame.
 //------------------------------------------------------------------------------------
 
-F_NT_EVENTHANDLER = addMissionEventHandler 
-["Draw3D", 
+F_NT_EVENTHANDLER = addMissionEventHandler
+["Draw3D",
 {
 	if F_NT_NAMETAGS_ON then
 	{	call f_fnc_nametagUpdate	};


### PR DESCRIPTION
See issue #152.

I didn't want to add this check for every component that's not useful to logic units, because it'd require a check for the player's side which requires waiting for the playing to not be Null.
But this might break components or inadvertently change the initialization order of the components which might lead to other unforeseen consequences.
So I think it's better to only disable components which are actively causing problems for logic units.