### PR TITLE
Issue 139: Add more type-checks for 'params'

### DIFF
--- a/f/FTMemberMarkers/f_localFTMemberMarker.sqf
+++ b/f/FTMemberMarkers/f_localFTMemberMarker.sqf
@@ -11,7 +11,7 @@ private ["_mkrName","_mkr","_mkrBorder","_pos","_mkrborderName","_dir"];
 // SET KEY VARIABLES
 // Using variables passed to the script instance, we will create some local variables:
 
-params ["_unit"];
+params [["_unit", objNull, [objNull]]];
 
 _mkrName = Format ["mkr_%1",_unit];
 _mkrborderName = Format ["mkrB_%1",_unit];

--- a/f/authorisedCrew/fn_authorisedCrewCheck.sqf
+++ b/f/authorisedCrew/fn_authorisedCrewCheck.sqf
@@ -17,7 +17,11 @@ params [
 	["_restrictcargo", false, [false]]
 ];
 
-_fromEH params ["_vehicle", "_vehicleRole", "_unitToCheck"];
+_fromEH params [
+	["_vehicle", objNull, [objNull]],
+	["_vehicleRole", "", [""]],
+	["_unitToCheck", objNull, [objNull]]
+];
 
 _warningMsg = localize "STR_f_UnauthorisedCrew_Warning";
 

--- a/f/briefing/f_loadoutNotes.sqf
+++ b/f/briefing/f_loadoutNotes.sqf
@@ -11,7 +11,7 @@ private ["_text","_weps","_items","_fnc_wepMags","_mags","_bp","_maxload","_atta
 // Local function to set the proper magazine count.
 _fnc_wepMags = {
 	private ["_wepMags","_magArr","_s"];
-	params ["_w"];
+	params [["_w", "", [""]]];
 
 	//Get possible magazines for weapon
 	_wepMags = getArray (configFile >> "CfgWeapons" >> _w >> "magazines");

--- a/f/dynamicViewDistance/fn_ehSetViewDistance.sqf
+++ b/f/dynamicViewDistance/fn_ehSetViewDistance.sqf
@@ -3,12 +3,13 @@
 
 // Parameters
 // Note: _oldCameraOn, _newCameraOn, and _uav are only used for the PlayerViewChanged event.
-params [ ["_unit", player],
-         ["_unit2_or_position", nil],
-         ["_veh", vehicle player],
-         ["_oldCameraOn", objNull],
-         ["_newCameraOn", objNull],
-         ["_uav", objNull]
+params [
+	["_unit", player, [objNull]],
+	["_unit2_or_position", nil],
+	["_veh", vehicle player, [objNull]],
+	["_oldCameraOn", nil],
+	["_newCameraOn", nil],
+	["_uav", objNull, [objNull]]
 ];
 
 private _vd = f_var_viewDistance_default;

--- a/f/groupMarkers/f_setLocalGroupMarkers.sqf
+++ b/f/groupMarkers/f_setLocalGroupMarkers.sqf
@@ -22,7 +22,7 @@ if (!isDedicated && (isNull player)) then
 // The following code detects what faction the player's slot belongs to, and stores
 // it in the private variable _unitfaction
 params [
-	["_unitfaction", toLower (faction (leader group player))]
+	["_unitfaction", toLower (faction (leader group player)), [""]]
 ];
 
 // ====================================================================================

--- a/f/groupMarkers/fn_localGroupMarker.sqf
+++ b/f/groupMarkers/fn_localGroupMarker.sqf
@@ -2,14 +2,15 @@
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 // ====================================================================================
 
-// DECLARE PRIVATE VARIABLES
-
-// ====================================================================================
-
 // SET KEY VARIABLES
 // Using variables passed to the script instance, we will create some local variables:
 
-params["_grpName",["_mkrType","b_hq"],"_mkrText",["_mkrColor","ColorBlack"]];
+params [
+	["_grpName", "", [""]],
+	["_mkrType", "b_hq", [""]],
+	["_mkrText", "", [""]],
+	["_mkrColor","ColorBlack", [""]]
+];
 
 private _grp = missionNamespace getVariable [_grpName,grpNull];
 private _mkrName = format ["mkr_%1",_grpName];

--- a/f/groupMarkers/fn_localSpecialistMarker.sqf
+++ b/f/groupMarkers/fn_localSpecialistMarker.sqf
@@ -11,7 +11,12 @@ private ["_mkr"];
 // SET KEY VARIABLES
 // Using variables passed to the script instance, we will create some local variables:
 
-params["_untName",["_mkrType","b_hq"],"_mkrText",["_mkrColor","ColorBlack"]];
+params [
+	["_untName", "", [""]],
+	["_mkrType", "b_hq", [""]],
+	["_mkrText", "", [""]],
+	["_mkrColor","ColorBlack", [""]]
+];
 
 private _mkrName = format ["mkr_%1",_untName];
 private _unt = missionNamespace getVariable [_untName, objNull];

--- a/f/mapClickTeleport/fn_mapClickTeleportParachute.sqf
+++ b/f/mapClickTeleport/fn_mapClickTeleportParachute.sqf
@@ -5,7 +5,9 @@
 //add aparachute as backpack and restore the old backpack on landing
 
 private ["_bp","_bpi"];
-params ["_unit"];
+params [
+	["_unit", objNull, [objNull]]
+];
 _bp = backpack _unit;
 _bpi = backPackItems _unit;
 

--- a/f/missionConditions/fn_SetFog.sqf
+++ b/f/missionConditions/fn_SetFog.sqf
@@ -11,7 +11,10 @@ private ["_strength","_decay","_base"];
 // SET KEY VARIABLES
 // We interpret the values parsed to the script. If the function was called from the parameters those values are used.
 
-params ["_fog", ["_transition",0]];
+params [
+	["_fog", 0, [0]],
+	["_transition", 0, [0]]
+];
 
 // Exit when using mission settings
 if ( _fog == 4 ) exitWith {};

--- a/f/missionConditions/fn_SetTime.sqf
+++ b/f/missionConditions/fn_SetTime.sqf
@@ -46,18 +46,20 @@ _sunset = [floor (_sunsetSunrise select 1), floor (((_sunsetSunrise select 1) % 
 
 // function for correcting adding hours and minutes to hours and minutes
 _addTime = {
-    params ["_time1","_time2"];
-    _result = [_time1,_time2] call BIS_fnc_vectorAdd;
-    while { _result select 1 > 60 } do { // convert extra minutes into hours
-        _result set [1,(_result select 1) - 60];
-        _result set [0,(_result select 0) + 1];
-    };
-    // make sure hour is in range [0,23]
-    _result set [0,(_result select 0) % 24];
-    if (_result select 0 < 0) then {
-        _result set [0,(_result select 0) + 24];
-    };
-    _result
+	params [
+		["_time1", [], [[]], 2],
+		["_time2", [], [[]], 2]
+	];
+	_result = _time1 vectorAdd _time2;
+	while { _result select 1 > 60 } do { // convert extra minutes into hours
+		_result = _result vectorAdd [1,-60];
+	};
+	// make sure hour is in range [0,23]
+	_result set [0,(_result select 0) % 24];
+	if (_result select 0 < 0) then {
+		_result = _result vectorAdd [24,0];
+	};
+	_result
 };
 
 // ====================================================================================

--- a/f/setGroupID/fn_setGroupID.sqf
+++ b/f/setGroupID/fn_setGroupID.sqf
@@ -5,7 +5,10 @@
 // DECLARE VARIABLES
 private ["_grp"];
 
-params ["_grp_var", "_grp_id"];
+params [
+	["_grp_var", "", [""]],
+	["_grp_id", "", [""]]
+];
 
 // Check first if the group exists
 


### PR DESCRIPTION
Add typechecks to `params`.
Replace `BIS_fnc_vectorAdd` with `vectorAdd`.

Note: This pull request does not completely resolve issue #139.