### PR TITLE
setAISkill: Revert behaviour of arguments.

### DIFF
--- a/f/setAISkill/f_setAISkill.sqf
+++ b/f/setAISkill/f_setAISkill.sqf
@@ -9,18 +9,11 @@ sleep 2;
 
 // ====================================================================================
 
-// DECLARE VARIABLES AND FUNCTIONS
-
-// If an array of units was passed, the skill change will apply only to the units in the array
-params [["_units", [], [[]]]];
-
-// ====================================================================================
-
 // RUN THE SCRIPT ONLY SERVER SIDE
 
-//If _units is empty, then it is called from init.sqf and should only run on the server.
+//If the argument is an empty array, then it is called from init.sqf and should only run on the server.
 //Otherwise it should be allowed to run on the server or on the headless client.
-if (count _units == 0) then {
+if (count _this == 0) then {
 	if (!isServer) exitWith {};
 } else {
 	if (!isServer && hasInterface) exitWith {};
@@ -30,9 +23,7 @@ if (count _units == 0) then {
 
 // SET KEY VARIABLES
 // If an array of units was passed, the skill change will apply only to the units in the array
-if (count _units == 0) then {
-	_units = allUnits;
-};
+private _units = if (count _this > 0) then [{_this},{allUnits}];
 
 // ====================================================================================
 


### PR DESCRIPTION
We cannot use `params` here because the argument is an array of objects.
With the `params` change, we changed the behaviour because we expected an array that contains the array of units instead. This reverts it back to the old documented behaviour.
No additional typechecks are needed as `f_fnc_setAISkill` is called and `getVariable` is used on each array element. Both would throw a script error if the element wasn't an object.