### PR TITLE
groupMarkers: support JIP groups

### DIFF
--- a/f/groupMarkers/fn_localGroupMarker.sqf
+++ b/f/groupMarkers/fn_localGroupMarker.sqf
@@ -17,19 +17,15 @@ private _mkrName = format ["mkr_%1",_grpName];
 // ====================================================================================
 
 // WAIT FOR GROUP TO EXIST IN-MISSION
+
+//If the group does not exist in this mission file, then we can exit.
+if (isNull _grp) exitWith {};
+
 // We wait for the group to have members before creating the marker.
-
-if (isNull _grp) then
+if (count units _grp == 0) then
 {
-	waitUntil { sleep 3; _grp = missionNamespace getVariable [_grpName,grpNull]; count (units _grp) > 0 };
+	waitUntil { sleep 5; _grp = missionNamespace getVariable [_grpName,grpNull]; count units _grp > 0 };
 };
-
-// ====================================================================================
-
-// EXIT FOR EMPTY GROUPS (PART I)
-// If the group is empty, this script exits.
-
-if (isnil "_grp") exitWith {};
 
 // ====================================================================================
 


### PR DESCRIPTION
Previously, markers for all possible groups were created at position `[0,0]` and they did not seem to update for JIP groups. This pull request aims to solve both of these issues.

When testing this I suggest using multiple people, the dedicated server, and specialist slots (to test both group- and specialist-markers simultaneously).