### PR TITLE
WS convoy improvements

### DIFF
--- a/ws_fnc/AI/fn_taskConvoy.sqf
+++ b/ws_fnc/AI/fn_taskConvoy.sqf
@@ -52,6 +52,7 @@ if (isNull _leadv || _marker == "" || !local _leadV) exitWith {};
 _convoy = _leadv call ws_fnc_collectObjectsNum;
 _waypoints = _marker call ws_fnc_collectMarkers;
 _run = true;
+_wasInterrupted = false;
 
 // Check if the convoy is in a condition to move at all
 if (({!canMove _x || !alive _x || (!isNull (_x findNearestEnemy (getPosATL _x)))} count _convoy) > 0) then {_run = false;};

--- a/ws_fnc/AI/fn_taskConvoy.sqf
+++ b/ws_fnc/AI/fn_taskConvoy.sqf
@@ -20,7 +20,7 @@ Minimal:
 [leadingVehicle,"firstMarker"] spawn ws_fnc_taskConvoy
 
 Full:
-[leadingVehicle,"firstMarker",speedLimit,allowInterrupt,"finalWaypointMode",{codeOnEnd}] spawn ws_fnc_taskConvoy
+[leadingVehicle,"firstMarker",speedLimit,allowInterrupt,"finalWaypointMode1","finalWaypointMode2",{codeOnEnd}] spawn ws_fnc_taskConvoy
 
 PARAMETERS
 1. The leading vehicle (all other vehicles should share the same naming template) 					 	| MANDATORY - object
@@ -28,7 +28,8 @@ PARAMETERS
 3. Speed limit in km/h (the slower the more reliably the convoy will move) 								| OPTIONAL - any number (default: 15)
 4. Whether the convoy will be interrupted by being attacked. If false, the convoy will ignore contact and try to proceed. 	| OPTIONAL - bool (default true)
 5. What waypoint type to assign to passenger units after they dismount .						| OPTIONAL - string  waypoint type https://community.bistudio.com/wiki/setWaypointType (default "SENTRY")
-6. Arbitrary code to executed when the convoy script completes. Will be executed in a scheduled environment. 	| OPTIONAL - code (default {}).  The arguments passed to the code will be [_vehiclesInConvoy,_passengerGroups,_wasInterrupted] (array of objects, array of groups, bool) - access them with params.
+6. What waypoint type to assign to fighting vehicles after reaching the destination.						| OPTIONAL - string  waypoint type https://community.bistudio.com/wiki/setWaypointType (default "SENTRY")
+7. Arbitrary code to executed when the convoy script completes. Will be executed in a scheduled environment. 	| OPTIONAL - code (default {}).  The arguments passed to the code will be [_vehiclesInConvoy,_passengerGroups,_wasInterrupted] (array of objects, array of groups, bool) - access them with params.
 
 EXAMPLE
 [cv,"cvwp"] spawn ws_fnc_taskConvoy - All vehicles sharing the cv-name (cv,cv_1,cv_2...) would follow the route indicated by the markers sharing the "cvwp"-name ("cvwp","cvwp_1","cvwp_2"...)
@@ -43,6 +44,7 @@ params [
 	["_speedLimit", 15, [0]],
 	["_allowInterrupt",false],
 	["_finalwp","SENTRY"],
+	["_finalwpcrew","SENTRY"],
 	["_endCode",{}]
 ];
 
@@ -161,7 +163,7 @@ _veh doMove (getPosATL _veh);
 
 			// If yes, only give it a sentry WP
 			if (canFire _veh) then {
-				[(group _x),_veh,[_finalwp,5]] call ws_fnc_addWaypoint;
+				[(group _x),_veh,[_finalwpCrew,5]] call ws_fnc_addWaypoint;
 			} else {
 				// If the vehicle can't shoot, let the crew dismount too
 				(group driver _veh) leaveVehicle _veh;

--- a/ws_fnc/AI/fn_taskConvoy.sqf
+++ b/ws_fnc/AI/fn_taskConvoy.sqf
@@ -42,9 +42,9 @@ params [
 	["_leadv", objNull],
 	["_marker", "", ["",objNull,[]]],
 	["_speedLimit", 15, [0]],
-	["_allowInterrupt",false],
-	["_finalwp","SENTRY"],
-	["_finalwpcrew","SENTRY"],
+	["_allowInterrupt",true,[true]],
+	["_finalwp","SENTRY",[""]],
+	["_finalwpcrew","SENTRY",[""]],
 	["_endCode",{}]
 ];
 
@@ -55,6 +55,7 @@ _convoy = _leadv call ws_fnc_collectObjectsNum;
 _waypoints = _marker call ws_fnc_collectMarkers;
 _run = true;
 _wasInterrupted = false;
+_passengerGroups = [];
 
 // Check if the convoy is in a condition to move at all
 if (({!canMove _x || !alive _x || (!isNull (_x findNearestEnemy (getPosATL _x)))} count _convoy) > 0) then {_run = false;};


### PR DESCRIPTION
This PR adds some new functionality for ws_fnc_taskConvoy.

- The waypoint type for dismounts can now be specified in the function call, rather than being hardcoded
- The waypoint type for combat vic crew can also be specified separately
- You can now tell the convoy to attempt to ignore threats
- You can now specify arbitrary code to execute when the convoy routine completes, with the convoy vehicles, dismount groups, and interrupted status available as params