### PR TITLE
Parameterise disableThermals

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -272,6 +272,17 @@ class Params
 		default = 0;
 	};
 	
+// F3 - Disable Thermals Parameters
+// Credits and documentation: https://github.com/folkarps/F3/wiki
+
+	class f_param_disableThermals
+	{
+		title = "Disable Thermals mode";
+		values[] = {0,1,2};
+		texts[] = {"Mission whitelist (default)","Ignore mission whitelist","Allow all thermals"};
+		default = 0;
+	};
+	
 // ============================================================================================
 
 // F3 - Caching

--- a/description.ext
+++ b/description.ext
@@ -279,7 +279,7 @@ class Params
 	{
 		title = "Disable Thermals mode";
 		values[] = {0,1,2};
-		texts[] = {"Mission whitelist (default)","Ignore mission whitelist","Allow all thermals"};
+		texts[] = {"Mission allow list (default)","Disable all vehicle thermals","Allow all vehicle thermals"};
 		default = 0;
 	};
 	

--- a/f/disableThermals/fn_disableThermals.sqf
+++ b/f/disableThermals/fn_disableThermals.sqf
@@ -2,6 +2,9 @@
 // Credits and documentation: https://github.com/folkarps/F3/wiki
 // ====================================================================================
 
+// If disableThermals is turned off by the mission parameter, don't run
+if (f_param_disableThermals == 2) exitWith {};
+
 // DECLARE VARIABLES AND FUNCTIONS
 
 private ["_allowedList", "_allowedTypes", "_allowedUnits"];
@@ -18,10 +21,13 @@ f_var_disableThermals_enabled = true;
 
 _allowedTypes = [];
 _allowedUnits = [];
-{
-	if (_x isEqualType "") then {_allowedTypes pushBack _x};
-	if (_x isEqualType objNull) then {_allowedUnits pushBack _x};
-} forEach _allowedList;
+// Only use the whitelists if the parameter mode is set for that. Otherwise, leave whitelists empty.
+if (f_param_disableThermals == 0) then {
+	{
+		if (_x isEqualType "") then {_allowedTypes pushBack _x};
+		if (_x isEqualType objNull) then {_allowedUnits pushBack _x};
+	} forEach _allowedList;
+};
 
 // PERFORM CHECKS
 // Check if any vehicle is one of the allowed vehicles or in the allowed types, if not, disable their thermals.


### PR DESCRIPTION
Since thermals are a bit less OP now, it might be nice to give hosts the option to try them out from time to time. This PR adds a parameter to override mission configured disableThermals (in either direction - force off, or force on).