### PR TITLE
Rework FCS override position calculation

### DIFF
--- a/f/fcs/fn_fcsCommanderOverride.sqf
+++ b/f/fcs/fn_fcsCommanderOverride.sqf
@@ -10,8 +10,17 @@ params ["_vehicle","_caller"];
 if (isNull cursorObject) then {
 	["NO TARGET",1] remoteExec ["f_fnc_fcsLocalWarning",commander _vehicle];
 } else {
-	// Get the position of the centre of the targeted object at the time of the override
-	_overrideTarget = (cursorObject modelToWorldWorld (boundingCenter cursorObject));
+	// Get the position of the targeted object at the time of the override
+	private _positionATL = getPosATL cursorObject;
+	// If the position is below ground level (partially sunken object) make the targeted position just above ground level
+	if ((_positionATL select 2) < 0) then {
+		_positionATL set [2,1];
+	} else {
+		// otherwise, try to aim approximately for the vertical middle and not at its feet
+		_positionATL = _positionATL vectorAdd [0,0,1.5];
+	};
+	// Convert to ASL for lockCameraTo
+	private _overrideTarget = ATLtoASL _positionATL;
 	// Order the gunner to aim their camera at the target position
 	[_vehicle,[_overrideTarget,_vehicle unitTurret (gunner _vehicle),true]] remoteExec ["lockCameraTo",gunner _vehicle];
 	// Display a HUD indicator for the gunner


### PR DESCRIPTION
At the moment the FCS override uses boundingCenter to determine what world position to aim at. This command has [inconsistent results](https://community.bistudio.com/wiki/File:arma3_static-machinegun-bounding-center.png), and can lead to the gunner's aim being pointed somewhere other than expected.

This PR changes to a more advanced calculation, which ensures the target position is always above ground level and is less likely to be far above the object. It still has some potential edge cases when a model has a fucked up centre point, but it should be better than boundingCenter's complete unreliability.