### PR TITLE
Fix radioChannelsUnified

### DIFF
--- a/f/radio/fn_radioChannels.sqf
+++ b/f/radio/fn_radioChannels.sqf
@@ -51,7 +51,7 @@ if (isServer) then {
 
 	// Flatten all these arrays into one single list for potential later use
 	f_var_radioChannelsUnified = [];
-	f_var_radioChannelsUnified append (flatten (values f_var_radioChannels apply {_x select 1}));
+	f_var_radioChannelsUnified append (flatten (values f_var_radioChannels apply {_x select 2}));
 	f_var_radioChannelsUnified = f_var_radioChannelsUnified arrayIntersect f_var_radioChannelsUnified;
 	
 	// If channels are not to be split, only create one.


### PR DESCRIPTION
The radioChannelsUnified variable was referencing the wrong array element, resulting in a flattened array of colour values instead of eligibility items. Fortunately this isn't used anywhere by default, but still worth fixing.