### PR TITLE
409 Radio improvements

### DIFF
--- a/f/briefing/fn_createBriefing.sqf
+++ b/f/briefing/fn_createBriefing.sqf
@@ -22,6 +22,11 @@ private _fnc_debug = {
 
 // ====================================================================================
 
+// Create briefing section for other components to use
+player createDiarySubject ["fa3_actions","Player Actions"];
+
+// ====================================================================================
+
 // DETECT PLAYER FACTION (use faction from group leader)
 private _unitfaction = toLower ([leader group player] call f_fnc_virtualFaction);
 

--- a/f/radio/f_channelsList.sqf
+++ b/f/radio/f_channelsList.sqf
@@ -30,6 +30,7 @@ There is a maximum of 10 channels at any time. Add in these radios for GM and CS
 _channelName1 = "¤  LR Channel 1";
 _channelColour1 = [1, 0.3, 0.1, 1];
 _channelList1 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_black_F"
 ];
 
@@ -37,6 +38,7 @@ _channelList1 = [
 _channelName2 = "¤  LR Channel 2";
 _channelColour2 = [0,0.9,0,1];
 _channelList2 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_digi_F",
 	"vehAAF_COV",
 	"vehAAF_IFV1",
@@ -61,6 +63,7 @@ _channelList2 = [
 _channelName3 = "¤  LR Channel 3";
 _channelColour3 = [0,0.9,0,1];
 _channelList3 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_eaf_F",
 	"vehLDF_COV",
 	"vehLDF_IFV1",
@@ -85,6 +88,7 @@ _channelList3 = [
 _channelName4 = "¤  LR Channel 4";
 _channelColour4 = [0.9,0,0,1];
 _channelList4 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_ghex_F",
 	"vehCSAT_COV",
 	"vehCSAT_IFV1",
@@ -109,6 +113,7 @@ _channelList4 = [
 _channelName5 = "¤  LR Channel 5";
 _channelColour5 = [0.9,0,0,1];
 _channelList5 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_hex_F",
 	"vehCSAT_COV",
 	"vehCSAT_IFV1",
@@ -133,6 +138,7 @@ _channelList5 = [
 _channelName6 = "¤  LR Channel 6";
 _channelColour6 = [0.9,0,0,1];
 _channelList6 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_oucamo_F",
 	"vehCSAT_COV",
 	"vehCSAT_IFV1",
@@ -157,6 +163,7 @@ _channelList6 = [
 _channelName7 = "¤  LR Channel 7";
 _channelColour7 = [0.1,0.5,1,1];
 _channelList7 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_mtp_F",
 	"vehNATO_COV",
 	"vehNATO_IFV1",
@@ -181,6 +188,7 @@ _channelList7 = [
 _channelName8 = "¤  LR Channel 8";
 _channelColour8 = [0.1,0.5,1,1];
 _channelList8 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_wdl_F",
 	"vehNATO_COV",
 	"vehNATO_IFV1",
@@ -205,6 +213,7 @@ _channelList8 = [
 _channelName9 = "¤  LR Channel 9";
 _channelColour9 = [0.1,0.5,1,1];
 _channelList9 = [
+	"VirtualCurator_F",
 	"B_RadioBag_01_tropic_F",
 	"vehNATO_COV",
 	"vehNATO_IFV1",
@@ -229,5 +238,6 @@ _channelList9 = [
 _channelName10 = "¤  LR Channel 10";
 _channelColour10 = [0.9,0.2,0.9,1];
 _channelList10 = [
+	"VirtualCurator_F",
 	"Your stuff here!"
 ];

--- a/f/radio/f_channelsList.sqf
+++ b/f/radio/f_channelsList.sqf
@@ -35,7 +35,7 @@ _channelList1 = [
 
 // Channel 2 (default: AAF)
 _channelName2 = "¤  LR Channel 2";
-_channelColour2 = [0.06,0.9,0,1];
+_channelColour2 = [0,0.9,0,1];
 _channelList2 = [
 	"B_RadioBag_01_digi_F",
 	"vehAAF_COV",
@@ -59,7 +59,7 @@ _channelList2 = [
 
 // Channel 3 (default: LDF)
 _channelName3 = "¤  LR Channel 3";
-_channelColour3 = [0.06,0.9,0,1];
+_channelColour3 = [0,0.9,0,1];
 _channelList3 = [
 	"B_RadioBag_01_eaf_F",
 	"vehLDF_COV",

--- a/f/radio/f_channelsList.sqf
+++ b/f/radio/f_channelsList.sqf
@@ -27,14 +27,14 @@ There is a maximum of 10 channels at any time. Add in these radios for GM and CS
 */
 
 // Channel 1 (default: generic)
-_channelName1 = "LR Channel 1";
+_channelName1 = "¤  LR Channel 1";
 _channelColour1 = [1, 0.3, 0.1, 1];
 _channelList1 = [
 	"B_RadioBag_01_black_F"
 ];
 
 // Channel 2 (default: AAF)
-_channelName2 = "LR Channel 2";
+_channelName2 = "¤  LR Channel 2";
 _channelColour2 = [0.06,0.9,0,1];
 _channelList2 = [
 	"B_RadioBag_01_digi_F",
@@ -58,7 +58,7 @@ _channelList2 = [
 ];
 
 // Channel 3 (default: LDF)
-_channelName3 = "LR Channel 3";
+_channelName3 = "¤  LR Channel 3";
 _channelColour3 = [0.06,0.9,0,1];
 _channelList3 = [
 	"B_RadioBag_01_eaf_F",
@@ -82,7 +82,7 @@ _channelList3 = [
 ];
 
 // Channel 4 (default: CSAT Pacific)
-_channelName4 = "LR Channel 4";
+_channelName4 = "¤  LR Channel 4";
 _channelColour4 = [0.9,0,0,1];
 _channelList4 = [
 	"B_RadioBag_01_ghex_F",
@@ -106,7 +106,7 @@ _channelList4 = [
 ];
 
 // Channel 5 (default: CSAT Mediterranean)
-_channelName5 = "LR Channel 5";
+_channelName5 = "¤  LR Channel 5";
 _channelColour5 = [0.9,0,0,1];
 _channelList5 = [
 	"B_RadioBag_01_hex_F",
@@ -130,7 +130,7 @@ _channelList5 = [
 ];
 
 // Channel 6 (default: CSAT Urban)
-_channelName6 = "LR Channel 6";
+_channelName6 = "¤  LR Channel 6";
 _channelColour6 = [0.9,0,0,1];
 _channelList6 = [
 	"B_RadioBag_01_oucamo_F",
@@ -154,7 +154,7 @@ _channelList6 = [
 ];
 
 // Channel 7 (default: NATO Mediterranean)
-_channelName7 = "LR Channel 7";
+_channelName7 = "¤  LR Channel 7";
 _channelColour7 = [0.1,0.5,1,1];
 _channelList7 = [
 	"B_RadioBag_01_mtp_F",
@@ -178,7 +178,7 @@ _channelList7 = [
 ];
 
 // Channel 8 (default: NATO Woodland)
-_channelName8 = "LR Channel 8";
+_channelName8 = "¤  LR Channel 8";
 _channelColour8 = [0.1,0.5,1,1];
 _channelList8 = [
 	"B_RadioBag_01_wdl_F",
@@ -202,7 +202,7 @@ _channelList8 = [
 ];
 
 // Channel 9 (default: NATO Pacific)
-_channelName9 = "LR Channel 9";
+_channelName9 = "¤  LR Channel 9";
 _channelColour9 = [0.1,0.5,1,1];
 _channelList9 = [
 	"B_RadioBag_01_tropic_F",
@@ -226,7 +226,7 @@ _channelList9 = [
 ];
 
 // Channel 10 (default: unused)
-_channelName10 = "LR Channel 10";
+_channelName10 = "¤  LR Channel 10";
 _channelColour10 = [0.9,0.2,0.9,1];
 _channelList10 = [
 	"Your stuff here!"

--- a/f/radio/fn_radioAddHandlers.sqf
+++ b/f/radio/fn_radioAddHandlers.sqf
@@ -51,6 +51,9 @@ player addAction [
 	0
 ];
 
+// Disable AI voice
+[player,"NoVoice"] remoteExec ["setSpeaker",0,true];
+
 // EHs are persistent on respawn so if we respawned, we don't need to add those
 if _respawned exitWith {};
 
@@ -107,8 +110,6 @@ player addEventHandler ["Respawn", {
 if (typeOf player != "VirtualSpectator_F") then {
 	5 enableChannel true;
 };
-// Disable AI voice
-[player,"NoVoice"] remoteExec ["setSpeaker",0,true];
 
 // Set a variable on the player to prove they've got handlers
 player setVariable ["f_var_radioHandlersAdded",true];

--- a/f/radio/fn_radioAddHandlers.sqf
+++ b/f/radio/fn_radioAddHandlers.sqf
@@ -5,6 +5,7 @@
 This function adds local event handlers to the player which grant radio channels when picking up a backpack or entering a vehicle. It also makes an initial check to see what they've got to begin with.
 It's activated by f\radio\fn_radioChannels.sqf.
 =========================== */
+params [["_respawned",false]];
 
 // Wait for player to be properly initialised
 waitUntil {(!isNull player && {player == player}) && !(isNil "f_var_radioChannelsUnified")};
@@ -12,8 +13,46 @@ waitUntil {(!isNull player && {player == player}) && !(isNil "f_var_radioChannel
 // Add player to the correct channels if they have a backpack
 [player] spawn f_fnc_radioCheckChannels;
 
-// Now bail if they've already been handled
-if (player getVariable ["f_var_radioHandlersAdded",false]) exitWith {};
+// Now bail if they've already been handled, unless they respawned in which case they do need the actions adding
+if (player getVariable ["f_var_radioHandlersAdded",false] && !_respawned) exitWith {};
+
+// Players can manually toggle the radio of the vehicle they're in (for themselves only). This is persistent and per-vehicle. The unit's own channels (from items and variables) aren't affected.
+player addAction [
+	"Turn off vehicle radio",
+	{
+		params ["_target", "_caller", "_actionId", "_arguments"];
+		private _radioOn = (vehicle _caller) getVariable ["f_var_radioIsOn",true];
+		(vehicle _caller) setVariable ["f_var_radioIsOn",!_radioOn];
+		[_caller] spawn f_fnc_radioCheckChannels;
+	},
+	nil,
+	0,
+	false,
+	true,
+	"",
+	"vehicle _this != _this && {vehicle _this getVariable ['f_var_radioIsOn',true]}",
+	0
+];
+
+player addAction [
+	"Turn on vehicle radio",
+	{
+		params ["_target", "_caller", "_actionId", "_arguments"];
+		private _radioOn = (vehicle _caller) getVariable ["f_var_radioIsOn",true];
+		(vehicle _caller) setVariable ["f_var_radioIsOn",!_radioOn];
+		[_caller] spawn f_fnc_radioCheckChannels;
+	},
+	nil,
+	0,
+	false,
+	true,
+	"",
+	"vehicle _this != _this && {!(vehicle _this getVariable ['f_var_radioIsOn',true])}",
+	0
+];
+
+// EHs are persistent on respawn so if we respawned, we don't need to add those
+if _respawned exitWith {};
 
 // Update channels if they drop a backpack
 player addEventHandler ["put", { 
@@ -57,40 +96,10 @@ player addEventHandler ["seatSwitchedMan", {
 	[_unit1] spawn f_fnc_radioCheckChannels; 
 }];
 
-// Players can manually toggle the radio of the vehicle they're in (for themselves only). This is persistent and per-vehicle. The unit's own channels (from items and variables) aren't affected.
-player addAction [
-	"Turn off vehicle radio",
-	{
-		params ["_target", "_caller", "_actionId", "_arguments"];
-		private _radioOn = (vehicle _caller) getVariable ["f_var_radioIsOn",true];
-		(vehicle _caller) setVariable ["f_var_radioIsOn",!_radioOn];
-		[_caller] spawn f_fnc_radioCheckChannels;
-	},
-	nil,
-	0,
-	false,
-	true,
-	"",
-	"vehicle _this != _this && {vehicle _this getVariable ['f_var_radioIsOn',true]}",
-	0
-];
-
-player addAction [
-	"Turn on vehicle radio",
-	{
-		params ["_target", "_caller", "_actionId", "_arguments"];
-		private _radioOn = (vehicle _caller) getVariable ["f_var_radioIsOn",true];
-		(vehicle _caller) setVariable ["f_var_radioIsOn",!_radioOn];
-		[_caller] spawn f_fnc_radioCheckChannels;
-	},
-	nil,
-	0,
-	false,
-	true,
-	"",
-	"vehicle _this != _this && {!(vehicle _this getVariable ['f_var_radioIsOn',true])}",
-	0
-];
+// Add respawn protection
+player addEventHandler ["Respawn", {
+	true spawn f_fnc_radioAddHandlers;
+}];
 
 // Just to be sure...
 2 enableChannel false;
@@ -102,6 +111,7 @@ if (typeOf player != "VirtualSpectator_F") then {
 // Set a variable on the player to prove they've got handlers
 player setVariable ["f_var_radioHandlersAdded",true];
 
+// Add persistent check
 if (isNil "f_var_radioPersistentCheck") then {
 	f_var_radioPersistentCheck = true;
 	[] spawn {

--- a/f/radio/fn_radioAddHandlers.sqf
+++ b/f/radio/fn_radioAddHandlers.sqf
@@ -107,6 +107,8 @@ player addEventHandler ["Respawn", {
 if (typeOf player != "VirtualSpectator_F") then {
 	5 enableChannel true;
 };
+// Disable AI voice
+[player,"NoVoice"] remoteExec ["setSpeaker",0,true];
 
 // Set a variable on the player to prove they've got handlers
 player setVariable ["f_var_radioHandlersAdded",true];

--- a/f/radio/fn_radioAddHandlers.sqf
+++ b/f/radio/fn_radioAddHandlers.sqf
@@ -71,7 +71,8 @@ player addAction [
 	false,
 	true,
 	"",
-	"vehicle _this != _this && {vehicle _this getVariable ['f_var_radioIsOn',true]}"
+	"vehicle _this != _this && {vehicle _this getVariable ['f_var_radioIsOn',true]}",
+	0
 ];
 
 player addAction [
@@ -87,7 +88,8 @@ player addAction [
 	false,
 	true,
 	"",
-	"vehicle _this != _this && {!(vehicle _this getVariable ['f_var_radioIsOn',true])}"
+	"vehicle _this != _this && {!(vehicle _this getVariable ['f_var_radioIsOn',true])}",
+	0
 ];
 
 // Just to be sure...

--- a/f/radio/fn_radioAddHandlers.sqf
+++ b/f/radio/fn_radioAddHandlers.sqf
@@ -16,41 +16,6 @@ waitUntil {(!isNull player && {player == player}) && !(isNil "f_var_radioChannel
 // Now bail if they've already been handled, unless they respawned in which case they do need the actions adding
 if (player getVariable ["f_var_radioHandlersAdded",false] && !_respawned) exitWith {};
 
-// Players can manually toggle the radio of the vehicle they're in (for themselves only). This is persistent and per-vehicle. The unit's own channels (from items and variables) aren't affected.
-player addAction [
-	"Turn off vehicle radio",
-	{
-		params ["_target", "_caller", "_actionId", "_arguments"];
-		private _radioOn = (vehicle _caller) getVariable ["f_var_radioIsOn",true];
-		(vehicle _caller) setVariable ["f_var_radioIsOn",!_radioOn];
-		[_caller] spawn f_fnc_radioCheckChannels;
-	},
-	nil,
-	0,
-	false,
-	true,
-	"",
-	"vehicle _this != _this && {vehicle _this getVariable ['f_var_radioIsOn',true]}",
-	0
-];
-
-player addAction [
-	"Turn on vehicle radio",
-	{
-		params ["_target", "_caller", "_actionId", "_arguments"];
-		private _radioOn = (vehicle _caller) getVariable ["f_var_radioIsOn",true];
-		(vehicle _caller) setVariable ["f_var_radioIsOn",!_radioOn];
-		[_caller] spawn f_fnc_radioCheckChannels;
-	},
-	nil,
-	0,
-	false,
-	true,
-	"",
-	"vehicle _this != _this && {!(vehicle _this getVariable ['f_var_radioIsOn',true])}",
-	0
-];
-
 // Disable AI voice
 [player,"NoVoice"] remoteExec ["setSpeaker",0,true];
 

--- a/f/radio/fn_radioAddHandlers.sqf
+++ b/f/radio/fn_radioAddHandlers.sqf
@@ -100,12 +100,13 @@ if (typeOf player != "VirtualSpectator_F") then {
 // Set a variable on the player to prove they've got handlers
 player setVariable ["f_var_radioHandlersAdded",true];
 
-// Add persistent check
-f_var_radioPersistentCheck = true;
-[] spawn {
-	while {f_var_radioPersistentCheck} do {
-		sleep 10;
-		[player] spawn f_fnc_radioCheckChannels;
+if (isNil "f_var_radioPersistentCheck") then {
+	f_var_radioPersistentCheck = true;
+	[] spawn {
+		while {f_var_radioPersistentCheck} do {
+			sleep 10;
+			[player] spawn f_fnc_radioCheckChannels;
+		};
 	};
 };
 

--- a/f/radio/fn_radioAddHandlers.sqf
+++ b/f/radio/fn_radioAddHandlers.sqf
@@ -100,11 +100,21 @@ if (typeOf player != "VirtualSpectator_F") then {
 // Set a variable on the player to prove they've got handlers
 player setVariable ["f_var_radioHandlersAdded",true];
 
+// Add persistent check
+f_var_radioPersistentCheck = true;
+[] spawn {
+	while {f_var_radioPersistentCheck} do {
+		sleep 10;
+		[player] spawn f_fnc_radioCheckChannels;
+	};
+};
+
 // DEBUG
 if (f_param_debugMode == 1) then
 {
 	systemChat "DEBUG (fn_radioAddHandlers.sqf): added radio event handlers to local player";
 };
 
+// Check again!
 sleep 1;
 [player] spawn f_fnc_radioCheckChannels;

--- a/f/radio/fn_radioChannels.sqf
+++ b/f/radio/fn_radioChannels.sqf
@@ -100,6 +100,8 @@ if (hasInterface) then {
 		};
 	";
 	
+	waitUntil {scriptDone f_script_briefing};
+	
 	player createDiaryRecord ["fa3_actions","FA3 Radio",
 		format ["
 			<br/>
@@ -111,7 +113,7 @@ if (hasInterface) then {
 			<br/><br/>
 			VEHICLE RADIO - controls channels you have access to because of the vehicle you're in. Only affects you, is vehicle-specific, and is persistent within this mission.
 			<execute expression='%2'>Toggle off/on</execute>
-		",_personalRadioCode,_vehicleRadioCode
+		",_personalRadioCode,_vehicleRadioCode]
 	];
 };
 

--- a/f/radio/fn_radioChannels.sqf
+++ b/f/radio/fn_radioChannels.sqf
@@ -63,7 +63,7 @@ if (isServer) then {
 	for "_i" from 1 to (_channelCount) do {
 		_channelName = format ["%1",((f_var_radioChannels get _i) select 0)];
 		_channelColour = ((f_var_radioChannels get _i) select 1);
-		_channelID = (radioChannelCreate [_channelColour, _channelName, "%UNIT_NAME", []]);
+		_channelID = (radioChannelCreate [_channelColour, _channelName, "%CHANNEL_LABEL - %UNIT_GRP_NAME %UNIT_NAME", []]);
 		if (_channelID != _i) exitWith {diag_log format ["F3 Radio: Channel %1 creation failed - unacceptable change to channel list in f\radio\f_radioChannels.sqf or too many channels", _channelName]};
 	};
 

--- a/f/radio/fn_radioChannels.sqf
+++ b/f/radio/fn_radioChannels.sqf
@@ -102,7 +102,7 @@ if (hasInterface) then {
 	
 	waitUntil {scriptDone f_script_briefing};
 	
-	player createDiaryRecord ["fa3_actions","FA3 Radio",
+	player createDiaryRecord ["fa3_actions",["FA3 Radio",
 		format ["
 			<br/>
 			The FA3 Radio system provides long-range radio channels based on items in your inventory and the vehicle you're in.
@@ -114,6 +114,6 @@ if (hasInterface) then {
 			VEHICLE RADIO - controls channels you have access to because of the vehicle you're in. Only affects you, is vehicle-specific, and is persistent within this mission.
 			<execute expression='%2'>Toggle off/on</execute>
 		",_personalRadioCode,_vehicleRadioCode]
-	];
+	]];
 };
 

--- a/f/radio/fn_radioChannels.sqf
+++ b/f/radio/fn_radioChannels.sqf
@@ -35,16 +35,16 @@ if (isServer) then {
 	#include "f_channelsList.sqf";
 	
 	f_var_radioChannels = createHashmap;
-	f_var_radioChannels set [1, [_channelName1,_channelColour1, (_channelList1 apply {toLower _x})]];
-	f_var_radioChannels set [2, [_channelName2,_channelColour2, (_channelList2 apply {toLower _x})]];
-	f_var_radioChannels set [3, [_channelName3,_channelColour3, (_channelList3 apply {toLower _x})]];
-	f_var_radioChannels set [4, [_channelName4,_channelColour4, (_channelList4 apply {toLower _x})]];
-	f_var_radioChannels set [5, [_channelName5,_channelColour5, (_channelList5 apply {toLower _x})]];
-	f_var_radioChannels set [6, [_channelName6,_channelColour6, (_channelList6 apply {toLower _x})]];
-	f_var_radioChannels set [7, [_channelName7,_channelColour7, (_channelList7 apply {toLower _x})]];
-	f_var_radioChannels set [8, [_channelName8,_channelColour8, (_channelList8 apply {toLower _x})]];
-	f_var_radioChannels set [9, [_channelName9,_channelColour9, (_channelList9 apply {toLower _x})]];
-	f_var_radioChannels set [10, [_channelName10,_channelColour10,(_channelList10 apply {toLower _x})]];
+	f_var_radioChannels set [1, [_channelName1,_channelColour1, (_channelList1 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [2, [_channelName2,_channelColour2, (_channelList2 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [3, [_channelName3,_channelColour3, (_channelList3 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [4, [_channelName4,_channelColour4, (_channelList4 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [5, [_channelName5,_channelColour5, (_channelList5 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [6, [_channelName6,_channelColour6, (_channelList6 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [7, [_channelName7,_channelColour7, (_channelList7 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [8, [_channelName8,_channelColour8, (_channelList8 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [9, [_channelName9,_channelColour9, (_channelList9 apply {toLowerANSI _x})]];
+	f_var_radioChannels set [10, [_channelName10,_channelColour10,(_channelList10 apply {toLowerANSI _x})]];
 	
 	// You can also tag a specific unit or vehicle for access to specific channels by setting a variable on them:
 	// _unit setVariable ["f_var_radioChannelsObjectSpecific",[1,2,3],true];

--- a/f/radio/fn_radioChannels.sqf
+++ b/f/radio/fn_radioChannels.sqf
@@ -85,5 +85,33 @@ if (isServer) then {
 // Run clientside stuff
 if (hasInterface) then {
 	[] call f_fnc_radioAddHandlers;
+	
+	private _personalRadioCode = "
+		private _radioOn = player getVariable [""f_var_radioIsOn"",true];
+		player setVariable [""f_var_radioIsOn"",!_radioOn];
+		[player] spawn f_fnc_radioCheckChannels;
+	";
+	
+	private _vehicleRadioCode = "
+		if (!isNull objectParent player) then {
+			private _radioOn = (objectParent player) getVariable [""f_var_radioIsOn"",true];
+			(objectParent player) setVariable [""f_var_radioIsOn"",!_radioOn];
+			[player] spawn f_fnc_radioCheckChannels;
+		};
+	";
+	
+	player createDiaryRecord ["fa3_actions","FA3 Radio",
+		format ["
+			<br/>
+			The FA3 Radio system provides long-range radio channels based on items in your inventory and the vehicle you're in.
+			<br/><br/>
+			PERSONAL RADIO - controls channels you have access to because of your inventory. Only affects you, and is persistent within this mission.
+			<br/><br/>
+			<execute expression='%1'>Toggle off/on</execute>
+			<br/><br/>
+			VEHICLE RADIO - controls channels you have access to because of the vehicle you're in. Only affects you, is vehicle-specific, and is persistent within this mission.
+			<execute expression='%2'>Toggle off/on</execute>
+		",_personalRadioCode,_vehicleRadioCode
+	];
 };
 

--- a/f/radio/fn_radioCheckChannels.sqf
+++ b/f/radio/fn_radioCheckChannels.sqf
@@ -85,6 +85,11 @@ for "_i" from 1 to 2 do {
 			_channelsToAddTalk = [1];
 		};
 	};
+	
+	// Can't talk if you're down!
+	if !(_unit getVariable ["f_var_fam_conscious",true]) then {
+		_channelsToAddTalk = [];
+	};
 		
 	// Remove channels player shouldn't have access to
 	for "_i" from 1 to f_var_radioChannelCount do {

--- a/f/radio/fn_radioCheckChannels.sqf
+++ b/f/radio/fn_radioCheckChannels.sqf
@@ -9,6 +9,10 @@ params ["_unit"];
 // Skip if the unit is an AI, so formerly-player AI units can't break the radio channels of players they're local to.
 if !(isPlayer _unit) exitWith {};
 
+// Queue checks, don't let them overlap
+waitUntil {!(missionNamespace getVariable ["f_var_radioIsChecking",false])};
+f_var_radioIsChecking = true;
+
 _splitMode = f_var_radioSplitMode;
 
 // Initialise variables
@@ -110,3 +114,5 @@ for "_i" from 1 to 2 do {
 	// Delay between the two check cycles
 	sleep 1;
 };
+
+f_var_radioIsChecking = false;

--- a/f/radio/fn_radioCheckChannels.sqf
+++ b/f/radio/fn_radioCheckChannels.sqf
@@ -16,8 +16,6 @@ f_var_radioIsChecking = true;
 _splitMode = f_var_radioSplitMode;
 
 // Initialise variables
-private _radioChannels_unitSpecific = [];
-private _radioChannelsVehicleSpecific = [];
 private _channelObjects = [];
 private _channelsToAddListen = [];
 private _channelsToAddTalk = [];

--- a/f/radio/fn_radioCheckChannels.sqf
+++ b/f/radio/fn_radioCheckChannels.sqf
@@ -43,14 +43,14 @@ for "_i" from 1 to 2 do {
 		// If the vehicle radio is turned off, don't check for vehicle-provided channels.
 		if _vicRadioOn then {
 			// Check for vehicles. Don't add send permissions unless they're the driver.
-			if ((toLower str vehicle _unit) in _channelObjects) then {
+			if ((toLowerANSI str vehicle _unit) in _channelObjects) then {
 				_channelsToAddListen pushBackUnique _i;
 				if (_unit in [driver vehicle _unit,commander vehicle _unit,gunner vehicle _unit]) then {
 					_channelsToAddTalk pushBackUnique _i;
 				};
 			};
 			// Same for vehicle classes.
-			if ((toLower typeOf vehicle _unit) in _channelObjects) then {
+			if ((toLowerANSI typeOf vehicle _unit) in _channelObjects) then {
 				_channelsToAddListen pushBackUnique _i;
 				if (_unit in [driver vehicle _unit,commander vehicle _unit,gunner vehicle _unit]) then {
 					_channelsToAddTalk pushBackUnique _i;

--- a/init.sqf
+++ b/init.sqf
@@ -16,13 +16,6 @@ enableSaving [false, false];
 
 // ====================================================================================
 
-// F3 - Mute Orders and Reports
-// Credits and documentation: https://github.com/folkarps/F3/wiki
-
-{_x setSpeaker "NoVoice"} forEach playableUnits;
-
-// ====================================================================================
-
 // F3 - Mission Timer/Safe Start
 // Credits and documentation: https://github.com/folkarps/F3/wiki
 


### PR DESCRIPTION
In this PR for #409:
- INDFOR channels use a slightly greener shade of green (best I could do)
- LR channels have an identifier character to distinguish from base channels
- LR channels now have an informative callsign when in text (can't control VON indicator https://feedback.bistudio.com/T175722 )
- There is now a recurring check loop to try to catch cases where event checks fail
- Checks now queue instead of potentially happening at the same time
- Zeus can now access all channels by default