### PR TITLE
Coldbreath improvements

### DIFF
--- a/f/missionConditions/fn_ColdBreath.sqf
+++ b/f/missionConditions/fn_ColdBreath.sqf
@@ -2,9 +2,8 @@
 // Credits and documentation: https://github.com/folkarps/F3/wiki
 // ====================================================================================
 
-{
-   _x spawn {
-     while {alive _this} do {
+f_fnc_coldBreathLoop = compileFinal {
+	while {alive _this} do {
         sleep (4*(1 - getFatigue _this) + random 1);
         drop [["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8,1], "", "Billboard", 1,
            (1-((vectorMagnitude velocity _this) / 35)) *.75 max .05,
@@ -15,5 +14,10 @@
           _this selectionPosition "Head" vectorAdd [0,.02,0],
           velocityModelSpace _this vectorAdd [0, .15, 0], 1, 1.3, 1, .01, [.1,.22,.3,.35], [[1, 1, 1, 0.25],[1, 1, 1, 0]], [1], 1, 0, "", "", _this];
     };
+};
+
+{
+   _x spawn {
+     
   };
 } forEach allUnits;

--- a/f/missionConditions/fn_ColdBreath.sqf
+++ b/f/missionConditions/fn_ColdBreath.sqf
@@ -5,8 +5,8 @@ f_var_coldBreathLoop = true;
 
 f_fnc_coldBreathLoop = compileFinal {
 	while {alive _this && f_var_coldBreathLoop} do {
+		sleep (4*(1 - getFatigue _this) + random 1);
 		if (vehicle _this == _this) then {
-			sleep (4*(1 - getFatigue _this) + random 1);
 			drop [["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8,1], "", "Billboard", 1,
 			   (1-((vectorMagnitude velocity _this) / 35)) *.75 max .05,
 			   _this selectionPosition "Head" vectorAdd [0,.02,0],

--- a/f/missionConditions/fn_ColdBreath.sqf
+++ b/f/missionConditions/fn_ColdBreath.sqf
@@ -17,7 +17,12 @@ f_fnc_coldBreathLoop = compileFinal {
 };
 
 {
-   _x spawn {
-     
-  };
+   _x spawn f_fnc_coldBreathLoop;
 } forEach allUnits;
+
+addMissionEventHandler ["EntityCreated",{
+	params ["_entity"];
+	if (_entity isKindOf "CAManBase") then {
+		_entity spawn f_fnc_coldBreathLoop;
+	};
+}];

--- a/f/missionConditions/fn_ColdBreath.sqf
+++ b/f/missionConditions/fn_ColdBreath.sqf
@@ -4,15 +4,17 @@
 
 f_fnc_coldBreathLoop = compileFinal {
 	while {alive _this} do {
-        sleep (4*(1 - getFatigue _this) + random 1);
-        drop [["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8,1], "", "Billboard", 1,
-           (1-((vectorMagnitude velocity _this) / 35)) *.75 max .05,
-           _this selectionPosition "Head" vectorAdd [0,.02,0],
-           velocityModelSpace _this vectorAdd [0, .1, 0], 1, 1.3, 1, .01, [.1,.25,.33,.4], [[1, 1, 1, 0.25],[1, 1, 1, 0]], [1], 1, 0, "", "", _this];
-        drop [["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8,1], "", "Billboard", 1,
-          (1-((vectorMagnitude velocity _this) / 35)) *.75 max .05,
-          _this selectionPosition "Head" vectorAdd [0,.02,0],
-          velocityModelSpace _this vectorAdd [0, .15, 0], 1, 1.3, 1, .01, [.1,.22,.3,.35], [[1, 1, 1, 0.25],[1, 1, 1, 0]], [1], 1, 0, "", "", _this];
+		if (vehicle _this == _this) then {
+			sleep (4*(1 - getFatigue _this) + random 1);
+			drop [["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8,1], "", "Billboard", 1,
+			   (1-((vectorMagnitude velocity _this) / 35)) *.75 max .05,
+			   _this selectionPosition "Head" vectorAdd [0,.02,0],
+			   velocityModelSpace _this vectorAdd [0, .1, 0], 1, 1.3, 1, .01, [.1,.25,.33,.4], [[1, 1, 1, 0.25],[1, 1, 1, 0]], [1], 1, 0, "", "", _this];
+			drop [["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8,1], "", "Billboard", 1,
+			  (1-((vectorMagnitude velocity _this) / 35)) *.75 max .05,
+			  _this selectionPosition "Head" vectorAdd [0,.02,0],
+			  velocityModelSpace _this vectorAdd [0, .15, 0], 1, 1.3, 1, .01, [.1,.22,.3,.35], [[1, 1, 1, 0.25],[1, 1, 1, 0]], [1], 1, 0, "", "", _this];
+		};
     };
 };
 

--- a/f/missionConditions/fn_ColdBreath.sqf
+++ b/f/missionConditions/fn_ColdBreath.sqf
@@ -1,9 +1,10 @@
 // F3 - Cold Breath
 // Credits and documentation: https://github.com/folkarps/F3/wiki
 // ====================================================================================
+f_var_coldBreathLoop = true;
 
 f_fnc_coldBreathLoop = compileFinal {
-	while {alive _this} do {
+	while {alive _this && f_var_coldBreathLoop} do {
 		if (vehicle _this == _this) then {
 			sleep (4*(1 - getFatigue _this) + random 1);
 			drop [["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8,1], "", "Billboard", 1,


### PR DESCRIPTION
This PR does 2 main things:

- prevent units in vehicles from generating cold breath, to avoid noticeably misaligned breath particles (#404)
- make the system account for units that are created after the initial launch