### PR TITLE
Add safe respawn handling to brakeOverride

### DIFF
--- a/f/brakeOverride/fn_brakeOverride.sqf
+++ b/f/brakeOverride/fn_brakeOverride.sqf
@@ -24,6 +24,9 @@ player addAction [
     "(driver (vehicle _this) == _this) && {(!brakesDisabled vehicle _this) && ((vehicle _this) isKindOf 'LandVehicle') && !((vehicle _this) isKindOf 'StaticWeapon')}"
 ];
 
+// If this is a respawn then we don't need anything else
+if _respawned exitWith {};
+
 player addEventHandler ["Respawn", {
 	true call f_fnc_brakeOverride;
 }];

--- a/f/brakeOverride/fn_brakeOverride.sqf
+++ b/f/brakeOverride/fn_brakeOverride.sqf
@@ -4,8 +4,10 @@
 This component allows players to disable the automatic brakes of any ground vehicle they're driving. It is enabled by default in init.sqf.
 */
 
+params [["_respawned",false]];
+
 // Don't add the action if it's already got one
-if (player getVariable ["f_var_hasDriverAction",false]) exitWith { diag_log "brakeOverride: tried to add driver action on something that already has it"};
+if (player getVariable ["f_var_hasDriverAction",false] && !_respawned) exitWith { diag_log "brakeOverride: tried to add driver action on something that already has it"};
 
 // Add the action
 player addAction [
@@ -21,6 +23,10 @@ player addAction [
     "",
     "(driver (vehicle _this) == _this) && {(!brakesDisabled vehicle _this) && ((vehicle _this) isKindOf 'LandVehicle') && !((vehicle _this) isKindOf 'StaticWeapon')}"
 ];
+
+player addEventHandler ["Respawn", {
+	true call f_fnc_brakeOverride;
+}];
 
 // Add the variable to prove it's already done
 player setVariable ["f_var_hasDriverAction",true];


### PR DESCRIPTION
Actions aren't persistent across respawns, so if someone wanted to use respawns in a mission, this would need to be manually modified to accommodate it. This PR fixes that - the system will now automatically re-add actions on respawn.