### PR TITLE
Exclude AI from goggle-keeping

### DIFF
--- a/f/assignGear/f_assignGear_clothes.sqf
+++ b/f/assignGear/f_assignGear_clothes.sqf
@@ -105,7 +105,7 @@ if(count _rig > 0) then
 	_unit addVest (selectRandom _rig);
 };
 
-if(count _glasses > 0 && (_glasses findIf {_x == goggles _unit}) == -1) then 
+if(count _glasses > 0 && {!(_unit in (playableUnits + switchableUnits)) or {(_glasses findIf {_x == goggles _unit}) == -1}}) then 
 {
 	removeGoggles _unit;
 	_unit addGoggles (selectRandom _glasses);


### PR DESCRIPTION
The goggle-keeping code means that any faction whose units all start with the same goggles, including no goggles, will all get the same goggles even if there are other options in the assignGear goggles array, as long as their original type is in the array.

AI don't care about keeping their goggle choice, and missionmakers will usually want their assignGear choice to have full effect on AI, so this forces a random selection on AI.