### PR TITLE
[FAM] Don't readd a map if there wasn't one to start with

### DIFF
--- a/f/medical/fn_famPassOut.sqf
+++ b/f/medical/fn_famPassOut.sqf
@@ -76,7 +76,7 @@ if(local _unit && isPlayer _unit) then
         _unit removeMagazine _x;
     } foreach magazines _unit;
 
-    _unit setVariable ["f_var_fam_wound_down_items",["ItemMap", _unit getSlotItemName 612]];
+    _unit setVariable ["f_var_fam_wound_down_items",[_unit getSlotItemName 608, _unit getSlotItemName 612]];
     {
         _unit unlinkItem _x;
     } foreach (_unit getVariable ["f_var_fam_wound_down_items",[]]);


### PR DESCRIPTION
The current FAM implementation assumes the player had a map. This is bad - if they don't have one, perhaps for mission design reasons, they'll get a free one if they get downed and revived.

This fixes that.