### PR TITLE
[FAM] Allow use of all FAK/medkit types

### DIFF
--- a/f/functions.hpp
+++ b/f/functions.hpp
@@ -144,6 +144,7 @@ class F // Defines the "owner"
 		class famBriefing{};
 		class FAMdiagnose{};
 		class FAMdiagnoseInitUI{};
+		class famHasFAK{};
 	};
 	class disableThermals
 	{

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -106,7 +106,7 @@ private _healCodeInt = {
 	format ["Heal %1", name _unit],
 	_healIcon, 
 	_healIcon, 
-	"(!(_this getUnitTrait 'medic') || (_this call f_fnc_famHasFAK <= 0)) && {alive _target && _target distance _this < 3 && {damage _target > 0.25 && !(_target getVariable ['f_var_fam_conscious',true]) && {(_this call f_fnc_famHasFAK == 0) || (_target getVariable ['f_var_fam_hasfak',false] && {!(_target getVariable ['f_var_fam_hasfak_requiremedic',false]) || (_this getUnitTrait 'medic'))}}}", 
+	"(!(_this getUnitTrait 'medic') || (_this call f_fnc_famHasFAK <= 0)) && {alive _target && _target distance _this < 3 && {damage _target > 0.25 && !(_target getVariable ['f_var_fam_conscious',true]) && {(_this call f_fnc_famHasFAK == 0) || (_target getVariable ['f_var_fam_hasfak',false] && {!(_target getVariable ['f_var_fam_hasfak_requiremedic',false]) || (_this getUnitTrait 'medic'))}}}}", 
 	_healProg, _healCodeStart, _healCodeProg, _healCodeComp, _healCodeInt, [], _healTime, 19, false, false, false
 ] call BIS_fnc_holdActionAdd;
 

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -68,7 +68,7 @@ private _healCodeComp = {
 	_caller setVariable ["f_var_fam_flag",false];
 
 	// Medic heals to full only if they have a medikit. TODO CLS Support?
-	if (_caller getUnitTrait 'Medic' && (_caller call f_fnc_famHasFAK => 1)) then {
+	if (_caller getUnitTrait 'Medic' && (_caller call f_fnc_famHasFAK >= 1)) then {
 		_target setDamage 0;
 		hint "Patient healed fully with Medikit"; // feedback on resource consumption.
 	} else {	

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -106,7 +106,7 @@ private _healCodeInt = {
 	format ["Heal %1", name _unit],
 	_healIcon, 
 	_healIcon, 
-	"(!(_this getUnitTrait 'medic') || (_this call f_fnc_famHasFAK <= 0)) && {alive _target && _target distance _this < 3 && {damage _target > 0.25 && !(_target getVariable ['f_var_fam_conscious',true]) && {(_this call f_fnc_famHasFAK == 0) || (_target getVariable ['f_var_fam_hasfak',false] && {!(_target getVariable ['f_var_fam_hasfak_requiremedic',false]) || (_this getUnitTrait 'medic'))}}}}", 
+	"(!(_this getUnitTrait 'medic') || (_this call f_fnc_famHasFAK <= 0))  && { alive _target && _target distance _this < 3  && { damage _target > 0.25 && !(_target getVariable ['f_var_fam_conscious',true])  && {      (_this call f_fnc_famHasFAK == 0) || (_target getVariable ['f_var_fam_hasfak',false]) && {!(_target getVariable ['f_var_fam_hasfak_requiremedic',false]) || (_this getUnitTrait 'medic')}}}}", 
 	_healProg, _healCodeStart, _healCodeProg, _healCodeComp, _healCodeInt, [], _healTime, 19, false, false, false
 ] call BIS_fnc_holdActionAdd;
 

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -68,7 +68,7 @@ private _healCodeComp = {
 	_caller setVariable ["f_var_fam_flag",false];
 
 	// Medic heals to full only if they have a medikit. TODO CLS Support?
-	if (_caller getUnitTrait 'Medic' && (_caller call f_fnc_famHasFAK == 1)) then {
+	if (_caller getUnitTrait 'Medic' && (_caller call f_fnc_famHasFAK => 1)) then {
 		_target setDamage 0;
 		hint "Patient healed fully with Medikit"; // feedback on resource consumption.
 	} else {	

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -75,7 +75,7 @@ private _healCodeComp = {
 		_target setDamage 0.25;
 		if (_caller call f_fnc_famHasFAK == 0) then {
 			private _FAKs = (items _caller select {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401});
-			_caller removeItem (selectRandom _FAKs);; 
+			_caller removeItem (selectRandom _FAKs);
 			hint format ["Patient healed partially with FAK, %1 remaining. Medic required for further healing.",(count _FAKs) - 1]; // feedback on resource consumption.
 		} else {
 			hint "FAK used from patient's inventory";

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -106,7 +106,7 @@ private _healCodeInt = {
 	format ["Heal %1", name _unit],
 	_healIcon, 
 	_healIcon, 
-	"(!(_this getUnitTrait 'medic') || (_this call f_fnc_famHasFAK == 0)) && {alive _target && _target distance _this < 3 && {damage _target > 0.25 && !(_target getVariable ['f_var_fam_conscious',true]) && (_target getVariable ['f_var_fam_hasfak',false])}}", 
+	"(!(_this getUnitTrait 'medic') || (_this call f_fnc_famHasFAK <= 0)) && {alive _target && _target distance _this < 3 && {damage _target > 0.25 && !(_target getVariable ['f_var_fam_conscious',true]) && {(_this call f_fnc_famHasFAK == 0) || (_target getVariable ['f_var_fam_hasfak',false] && {!(_target getVariable ['f_var_fam_hasfak_requiremedic',false]) || (_this getUnitTrait 'medic'))}}}", 
 	_healProg, _healCodeStart, _healCodeProg, _healCodeComp, _healCodeInt, [], _healTime, 19, false, false, false
 ] call BIS_fnc_holdActionAdd;
 

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -74,7 +74,7 @@ private _healCodeComp = {
 	} else {	
 		_target setDamage 0.25;
 		if (_caller call f_fnc_famHasFAK == 0) then {
-			private _FAKs = (items _caller select {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401});
+			private _FAKs = (items _caller select {(getNumber (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "type")) == 401});
 			_caller removeItem (selectRandom _FAKs);
 			hint format ["Patient healed partially with FAK, %1 remaining. Medic required for further healing.",(count _FAKs) - 1]; // feedback on resource consumption.
 		} else {

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -116,6 +116,6 @@ private _healCodeInt = {
 	format ["Heal %1", name _unit],
 	_healIcon, 
 	_healIcon, 
-	"(_this getUnitTrait 'medic' && (_this call f_fnc_famHasFAK == 1)) && {alive _target && _target distance _this < 3 && {damage _target > 0 && !(_target getVariable ['f_var_fam_conscious',true])}}", 
+	"(_this getUnitTrait 'medic' && (_this call f_fnc_famHasFAK >= 1)) && {alive _target && _target distance _this < 3 && {damage _target > 0 && !(_target getVariable ['f_var_fam_conscious',true])}}", 
 	_healProg, _healCodeStart, _healCodeProg, _healCodeComp, _healCodeInt, [], _healMedicTime, 19, false, false, false
 ] call BIS_fnc_holdActionAdd;

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -16,8 +16,6 @@ private _healMedicTime = 4.5; // Action Duration
 
 // Starting Code
 private _healCodeStart = { 
-	params ["_target", "_caller", "_actionId", "_arguments"]; 
-
 	// this is needed to protect against BI bugs that remove all actions.
 	_caller setVariable ["f_var_fam_flag",true];
 	
@@ -62,14 +60,10 @@ private _healCodeStart = {
 }; 
 
 // Progress Code
-private _healCodeProg = { 
-	params ["_target", "_caller", "_actionId", "_arguments"]; 
-}; 
+private _healCodeProg = {}; 
 
 // Completed Code
 private _healCodeComp = { 
-	params ["_target", "_caller", "_actionId", "_arguments"]; 
-
 	// this is needed to protect against BI bugs that remove all actions.
 	_caller setVariable ["f_var_fam_flag",false];
 
@@ -92,8 +86,6 @@ private _healCodeComp = {
 
 // Interrupt Code
 private _healCodeInt = { 
-	params ["_target", "_caller", "_actionId", "_arguments"];
-
 	// this is needed to protect against BI bugs that remove all actions.
 	_caller setVariable ["f_var_fam_flag",false];
 

--- a/f/medical/fn_famAddHealAction.sqf
+++ b/f/medical/fn_famAddHealAction.sqf
@@ -74,14 +74,15 @@ private _healCodeComp = {
 	_caller setVariable ["f_var_fam_flag",false];
 
 	// Medic heals to full only if they have a medikit. TODO CLS Support?
-	if (_caller getUnitTrait 'Medic' && 'Medikit' in items _caller) then {
+	if (_caller getUnitTrait 'Medic' && (_caller call f_fnc_famHasFAK == 1)) then {
 		_target setDamage 0;
 		hint "Patient healed fully with Medikit"; // feedback on resource consumption.
 	} else {	
 		_target setDamage 0.25;
-		if ("FirstAidKit" in items _caller) then {
-			_caller removeItem "FirstAidKit"; 
-			hint format ["Patient healed partially with FAK, %1 remaining. Medic required for further healing.",count (items _caller select {_x == "FirstAidKit"})]; // feedback on resource consumption.
+		if (_caller call f_fnc_famHasFAK == 0) then {
+			private _FAKs = (items _caller select {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401});
+			_caller removeItem (selectRandom _FAKs);; 
+			hint format ["Patient healed partially with FAK, %1 remaining. Medic required for further healing.",(count _FAKs) - 1]; // feedback on resource consumption.
 		} else {
 			hint "FAK used from patient's inventory";
 			_target setVariable ["f_var_fam_used_fak",true,true];
@@ -113,7 +114,7 @@ private _healCodeInt = {
 	format ["Heal %1", name _unit],
 	_healIcon, 
 	_healIcon, 
-	"(!(_this getUnitTrait 'medic') || !('Medikit' in items _this)) && {alive _target && _target distance _this < 3 && {damage _target > 0.25 && !(_target getVariable ['f_var_fam_conscious',true]) && ('FirstAidKit' in items _this || _target getVariable ['f_var_fam_hasfak',false])}}", 
+	"(!(_this getUnitTrait 'medic') || (_this call f_fnc_famHasFAK == 0)) && {alive _target && _target distance _this < 3 && {damage _target > 0.25 && !(_target getVariable ['f_var_fam_conscious',true]) && (_target getVariable ['f_var_fam_hasfak',false])}}", 
 	_healProg, _healCodeStart, _healCodeProg, _healCodeComp, _healCodeInt, [], _healTime, 19, false, false, false
 ] call BIS_fnc_holdActionAdd;
 
@@ -123,6 +124,6 @@ private _healCodeInt = {
 	format ["Heal %1", name _unit],
 	_healIcon, 
 	_healIcon, 
-	"(_this getUnitTrait 'medic' && 'Medikit' in items _this) && {alive _target && _target distance _this < 3 && {damage _target > 0 && !(_target getVariable ['f_var_fam_conscious',true])}}", 
+	"(_this getUnitTrait 'medic' && (_this call f_fnc_famHasFAK == 1)) && {alive _target && _target distance _this < 3 && {damage _target > 0 && !(_target getVariable ['f_var_fam_conscious',true])}}", 
 	_healProg, _healCodeStart, _healCodeProg, _healCodeComp, _healCodeInt, [], _healMedicTime, 19, false, false, false
 ] call BIS_fnc_holdActionAdd;

--- a/f/medical/fn_famEH.sqf
+++ b/f/medical/fn_famEH.sqf
@@ -50,7 +50,7 @@ _ehHeal = _unit addEventHandler ["HandleHeal", {
         if (_healer getUnitTrait "Medic") then {
             hint "Patient healed with Medikit";
         } else {
-            hint format ["Patient healed partially with FAK, %1 remaining. Medic required for further healing.",count (items _healer select {_unit == "FirstAidKit"})];
+            hint format ["Patient healed partially with FAK, %1 remaining. Medic required for further healing.",count (items _unit select {(getNumber (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "type")) == 401})];
         };
 
     };

--- a/f/medical/fn_famHasFAK.sqf
+++ b/f/medical/fn_famHasFAK.sqf
@@ -2,11 +2,11 @@ params ["_unit"];
 private _FAKtype = -1;
 if (isNull _unit) exitWith { _FAKtype };
 
-if ((items _unit findIf {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401}) > -1) then {
+if ((items _unit findIf {(getNumber (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "type")) == 401}) > -1) then {
 	_FAKtype = 0; // FAK
 };
 
-if ((items _unit findIf {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 619}) > -1) then {
+if ((items _unit findIf {(getNumber (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "type")) == 619}) > -1) then {
 	_FAKtype = 1; // Medkit
 };
 

--- a/f/medical/fn_famHasFAK.sqf
+++ b/f/medical/fn_famHasFAK.sqf
@@ -1,0 +1,13 @@
+params ["_unit"];
+private _FAKtype = -1;
+if (isNull _unit) exitWith { _FAKtype };
+
+if ((items _unit findIf {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401}) > -1) then {
+	_FAKtype = 0; // FAK
+};
+
+if ((items _unit findIf {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 619}) > -1) then {
+	_FAKtype = 1; // Medkit
+};
+
+_FAKtype;

--- a/f/medical/fn_famHasFAK.sqf
+++ b/f/medical/fn_famHasFAK.sqf
@@ -1,15 +1,15 @@
 // FA Medical - FAK/medkit detector
-// Returns -1 if the unit has neither FAKs nor Medkit, returns 0 if they have a FAK but no Medkit, returns 1 if they have a Medkit
+// Returns -1 if the unit has neither FAKs nor Medkit, returns 0 if they have a FAK but no Medkit, returns 1 if they have a Medkit but no FAK, returns 2 if they have both
 params ["_unit"];
 private _FAKtype = -1;
 if (isNull _unit) exitWith { _FAKtype };
 
 if ((items _unit findIf {(getNumber (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "type")) == 401}) > -1) then {
-	_FAKtype = 0; // FAK
+	_FAKtype = _FAKtype + 1; // FAK
 };
 
 if ((items _unit findIf {(getNumber (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "type")) == 619}) > -1) then {
-	_FAKtype = 1; // Medkit
+	_FAKtype = _FAKtype + 2; // Medkit
 };
 
 _FAKtype;

--- a/f/medical/fn_famHasFAK.sqf
+++ b/f/medical/fn_famHasFAK.sqf
@@ -1,3 +1,5 @@
+// FA Medical - FAK/medkit detector
+// Returns -1 if the unit has neither FAKs nor Medkit, returns 0 if they have a FAK but no Medkit, returns 1 if they have a Medkit
 params ["_unit"];
 private _FAKtype = -1;
 if (isNull _unit) exitWith { _FAKtype };

--- a/f/medical/fn_famLoop.sqf
+++ b/f/medical/fn_famLoop.sqf
@@ -204,7 +204,7 @@ while {alive _unit && {local _unit}} do {
 			if (damage _unit == 0) then {
 				hint "Healed to full with Medikit";
 			} else {
-				hint format ["Healed partially with FAK, %1 remaining. Medic required for further healing.",count (items _unit select {_x == "FirstAidKit"})]
+				hint format ["Healed partially with FAK, %1 remaining. Medic required for further healing.",count (items _unit select {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401})]
 			};
 			_unit setVariable ["f_var_fam_selffak", false];
 		};

--- a/f/medical/fn_famLoop.sqf
+++ b/f/medical/fn_famLoop.sqf
@@ -204,7 +204,7 @@ while {alive _unit && {local _unit}} do {
 			if (damage _unit == 0) then {
 				hint "Healed to full with Medikit";
 			} else {
-				hint format ["Healed partially with FAK, %1 remaining. Medic required for further healing.",count (items _unit select {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401})]
+				hint format ["Healed partially with FAK, %1 remaining. Medic required for further healing.",count (items _unit select {(getNumber (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "type")) == 401})]
 			};
 			_unit setVariable ["f_var_fam_selffak", false];
 		};

--- a/f/medical/fn_famMedswap.sqf
+++ b/f/medical/fn_famMedswap.sqf
@@ -60,24 +60,5 @@ if (_itemsNeedUpdate) then {
 };
 
 // ====================================================================================
-/*
-// VEHICLE CREWS
-{
-	_crew = _x;
-	{
-		if (_x == "FirstAidKit" || {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 401}) then {
-			_itemType = _x;
-			_crew removeItem _x;
-			_roll = round random 10;
-			if (_roll >= 8) then {
-				_obj addItem "Bandage"; // 30% chance to get a bandage
-			} else {
-				if (_roll == 1) then {
-					_obj addItem _itemType; // 10% chance of a FAK.
-				};
-			};
-		};
-	} forEach items _crew;
-} foreach crew _obj;
 
 

--- a/f/medical/fn_famMedswap.sqf
+++ b/f/medical/fn_famMedswap.sqf
@@ -12,21 +12,23 @@ if (_obj getVariable ["f_var_assignGear_done", false]) exitWith {};
 
 private _itemType = "";
 
-// INFANTRY
-{
-	if (_x == "FirstAidKit" || {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 401}) then {
-		_itemType = _x;
-		_obj removeItem _x;
-		_roll = round random 10;
-		if (_roll >= 8) then {
-			_obj addItem "Bandage"; // 30% chance to get a bandage
-		} else {
-			if (_roll == 0) then {
-				_obj addItem _itemType; // 10% chance of a FAK.
+// INFANTRY & CREWS
+if (_obj isKindOf "CAManBase") exitWith {
+	{
+		if (_x == "FirstAidKit" || {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 401}) then {
+			_itemType = _x;
+			_obj removeItem _x;
+			_roll = round random 10;
+			if (_roll >= 8) then {
+				_obj addItem "Bandage"; // 30% chance to get a bandage
+			} else {
+				if (_roll == 0) then {
+					_obj addItem _itemType; // 10% chance of a FAK.
+				};
 			};
 		};
-	};
-} forEach items _obj;
+	} forEach items _obj;
+}; 
 
 // ====================================================================================
 
@@ -49,16 +51,16 @@ _itemsNeedUpdate = false;
 		_itemsCargo pushBack [_x,1];
 	};
 } forEach (_existingCargo #0);
+
 if (_itemsNeedUpdate) then {
 	clearItemCargoGlobal _obj;
 	{
-		_obj addItemCargoGlobal [_x #0,_x #1];
+		_obj addItemCargoGlobal _x;
 	} forEach _itemsCargo;
 };
 
-if (vehicle _obj == _obj) exitWith {}; 
 // ====================================================================================
-
+/*
 // VEHICLE CREWS
 {
 	_crew = _x;

--- a/f/medical/fn_famMedswap.sqf
+++ b/f/medical/fn_famMedswap.sqf
@@ -4,29 +4,27 @@
 
 params ["_obj"];
 
-// This is only to be used on the server-side preplaced AI or vehicles, with the expectation that anyone running headless client is capable of fixing things there.
-if !(isServer) exitWith {};
+// Exit if assignGear was run on this object
 if (_obj getVariable ["f_var_assignGear_done", false]) exitWith {};
 
 // MEDSWAP
-// Run through everything server side and replace FAKs (or equivalents) with Bandages. This also replaces all CDLC stuff with vanilla stuff.
+// Run through everything server side and replace some FAKs (or equivalents) with Bandages. 
+
+private _itemType = "";
 
 // INFANTRY
 {
 	if (_x == "FirstAidKit" || {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 401}) then {
+		_itemType = _x;
 		_obj removeItem _x;
 		_roll = round random 10;
 		if (_roll >= 8) then {
 			_obj addItem "Bandage"; // 30% chance to get a bandage
 		} else {
 			if (_roll == 0) then {
-				_obj addItem "FirstAidKit"; // 10% chance of a FAK.
+				_obj addItem _itemType; // 10% chance of a FAK.
 			};
 		};
-	};
-	if (_x != "Medikit" && {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 619}) then {
-		_obj removeItem _x;
-		_obj addItem "Medikit";
 	};
 } forEach items _obj;
 
@@ -40,14 +38,10 @@ _itemsNeedUpdate = false;
 {
 	_itemReplaced = false;
 	if (_x == "FirstAidKit" || {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 401}) then {
+		_itemType = _x;
 		_itemsQty = _existingCargo #1 #_forEachIndex;
 		_itemsCargo pushback ["Bandage",round _itemsQty * .75];
-		_itemsCargo pushback ["FirstAidKit",round _itemsQty * .25];
-		_itemReplaced = true;
-		_itemsNeedUpdate = true;
-	};
-	if (_x != "Medikit" && {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 619}) then {
-		_itemsCargo pushback "Medikit";
+		_itemsCargo pushback [_itemType,round _itemsQty * .25];
 		_itemReplaced = true;
 		_itemsNeedUpdate = true;
 	};
@@ -70,19 +64,16 @@ if (vehicle _obj == _obj) exitWith {};
 	_crew = _x;
 	{
 		if (_x == "FirstAidKit" || {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 401}) then {
+			_itemType = _x;
 			_crew removeItem _x;
 			_roll = round random 10;
 			if (_roll >= 8) then {
 				_obj addItem "Bandage"; // 30% chance to get a bandage
 			} else {
 				if (_roll == 1) then {
-					_obj addItem "FirstAidKit"; // 10% chance of a FAK.
+					_obj addItem _itemType; // 10% chance of a FAK.
 				};
 			};
-		};
-		if (_x != "Medikit" && {[configFile >> "CfgWeapons" >> _x >> "ItemInfo","type",-1] call BIS_fnc_returnConfigEntry == 619}) then {
-			_crew removeItem _x;
-			_crew addItem "Medikit";
 		};
 	} forEach items _crew;
 } foreach crew _obj;

--- a/f/medical/fn_famPassOut.sqf
+++ b/f/medical/fn_famPassOut.sqf
@@ -69,7 +69,10 @@ if(local _unit && isPlayer _unit) then
     }; 
 	if (_unit call f_fnc_famHasFAK > -1) then {
 		_unit setVariable ["f_var_fam_hasfak",true,true];  
-    }; 
+    };
+	if (_unit call f_fnc_famHasFAK == 1) then {
+		_unit setVariable ["f_var_fam_hasfak_requiremedic",true,true];
+	};
 
     _unit setVariable ["f_var_fam_wound_down_mags",magazines _unit];
     {

--- a/f/medical/fn_famPassOut.sqf
+++ b/f/medical/fn_famPassOut.sqf
@@ -67,7 +67,7 @@ if(local _unit && isPlayer _unit) then
 	if ("Bandage" in magazines _unit) then {
 		_unit setVariable ["f_var_fam_hasbandage",true,true];  
     }; 
-	if ("FirstAidKit" in items _unit) then {
+	if (_unit call f_fnc_famHasFAK > -1) then {
 		_unit setVariable ["f_var_fam_hasfak",true,true];  
     }; 
 

--- a/f/medical/fn_famPassOut.sqf
+++ b/f/medical/fn_famPassOut.sqf
@@ -70,7 +70,7 @@ if(local _unit && isPlayer _unit) then
 	if (_unit call f_fnc_famHasFAK > -1) then {
 		_unit setVariable ["f_var_fam_hasfak",true,true];  
     };
-	if (_unit call f_fnc_famHasFAK == 1) then {
+	if ((_unit call f_fnc_famHasFAK == 1) && {!(_unit getUnitTrait "Medic")}) then {
 		_unit setVariable ["f_var_fam_hasfak_requiremedic",true,true];
 	};
 

--- a/f/medical/fn_famWakeUp.sqf
+++ b/f/medical/fn_famWakeUp.sqf
@@ -51,7 +51,8 @@ if(local _unit) then
     };
     // reset these
     _unit setVariable ["f_var_fam_hasbandage",false,true];  
-    _unit setVariable ["f_var_fam_hasfak",false,true];  
+    _unit setVariable ["f_var_fam_hasfak",false,true]; 
+	_unit setVariable ["f_var_fam_hasfak_requiremedic",false,true];
 
     // reset the screen effects
     [4] spawn f_fnc_famWoundedEffect;

--- a/f/medical/fn_famWakeUp.sqf
+++ b/f/medical/fn_famWakeUp.sqf
@@ -45,8 +45,8 @@ if(local _unit) then
         _unit setVariable ["f_var_fam_used_bandage",false];
     };
     if (_unit getVariable ["f_var_fam_used_fak",false]) then {
-        private _FAKs = (items _caller select {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401});
-		_caller removeItem (selectRandom _FAKs);
+        private _FAKs = (items _unit select {(getNumber (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "type")) == 401});
+		_unit removeItem (selectRandom _FAKs);
         _unit setVariable ["f_var_fam_used_fak",false];
     };
     // reset these

--- a/f/medical/fn_famWakeUp.sqf
+++ b/f/medical/fn_famWakeUp.sqf
@@ -45,7 +45,8 @@ if(local _unit) then
         _unit setVariable ["f_var_fam_used_bandage",false];
     };
     if (_unit getVariable ["f_var_fam_used_fak",false]) then {
-        _unit removeItem "FirstAidKit";
+        private _FAKs = (items _caller select {(getNumber (configFile >> "CfgMagazines" >> _x >> "ItemInfo" >> "type")) == 401});
+		_caller removeItem (selectRandom _FAKs);
         _unit setVariable ["f_var_fam_used_fak",false];
     };
     // reset these


### PR DESCRIPTION
Currently only the exact vanilla FAK and Medikit items are accepted by FAM.
This PR changes it so anything that is equivalent to a FAK or Medikit is treated as one of those.

Also makes it so if a patient has a medkit, they can be revived if no one involved has a FAK.

WIP item: medical resource swapper still turns FAK/Medikit equivalents into FAKs/Medikits. That needs fixing but @costno should do it, not me, for reasons.