### PR TITLE
Tactical Ping button activates FCS override

### DIFF
--- a/f/fcs/fn_fcsBriefing.sqf
+++ b/f/fcs/fn_fcsBriefing.sqf
@@ -9,13 +9,13 @@ if (!hasInterface) exitWith {}; // Exit if not a player.
 waitUntil {!isNil "f_script_loadoutNotes"};
 waitUntil {scriptDone f_script_loadoutNotes};
 
-_fcs = player createDiaryRecord ["diary", ["FA3 Enhanced FCS","
+_fcs = player createDiaryRecord ["diary", ["FA3 Enhanced FCS",format ["
 <br/>
 Some vehicles in this mission are fitted with enhanced fire control systems. This adds some extra functionality relating to gunnery and targeting.
 <br/><br/>
 <font size='18'>COMMANDER'S OVERRIDE</font>
 <br/>
-The enhanced FCS allows the commander to automatically point the main gun at a target of their choosing. When the commander selects the Commander's Override from the action menu, the main gun will automatically traverse and elevate until it is pointing at the centre of the targeted object.
+The enhanced FCS allows the commander to automatically point the main gun at a target of their choosing. When the commander selects the Commander's Override from the action menu or presses Tactical Ping (%1), the main gun will automatically traverse and elevate until it is pointing at the centre of the targeted object.
 <br/>
 The commander must be aiming directly at an object to activate the override. Open ground or sky won't work. There must also be a gunner present for the override to work. The override will engage for a maximum of 4 seconds before releasing control.
 <br/><br/>
@@ -24,7 +24,7 @@ The commander must be aiming directly at an object to activate the override. Ope
 When the vehicle is struck by high-calibre weapons, there's a chance the FCS will suffer damage. If the FCS is damaged, the Commander's Override will be disabled, as well as the gun zeroing and auto-leading functions and all night vision equipment.
 <br/>
 The FCS can be repaired by a player with engineering training (for example, an FA3 vehicle driver) when they are in the gunner's seat.
-"]];
+",actionKeysNames ["tacticalPing",1,"Keyboard"]]]];
 
 // Set a variable so this won't be generated again by subsequent inits
 f_var_fcs_briefingDone = true;

--- a/f/fcs/fn_fcsInit.sqf
+++ b/f/fcs/fn_fcsInit.sqf
@@ -48,7 +48,7 @@ _vehicle addAction
 	1.5,	
 	false,	
 	true,	
-	"",	
+	"TacticalPing",	
 	"(_this == commander _target) && {!(isNull gunner _target) && !(_target getVariable [""f_var_fcsCommanderOverride_cooldown"",false]) && !(_target getVariable [""f_var_fcs_failure"",false])}", 
 	0,		
 	false,	


### PR DESCRIPTION
The FCS override action now uses the Tactical Ping button as its shortcut for more convenient access.