### PR TITLE
Better FCS briefing timing safeties for init fields

### DIFF
--- a/f/fcs/fn_fcsBriefing.sqf
+++ b/f/fcs/fn_fcsBriefing.sqf
@@ -8,6 +8,7 @@ This function generates a briefing tab describing the operation of the FA3 FCS. 
 if (!hasInterface) exitWith {}; // Exit if not a player.
 waitUntil {!isNil "f_script_loadoutNotes"};
 waitUntil {scriptDone f_script_loadoutNotes};
+if (!isNil "f_var_fcs_briefingDone") exitWith{};
 
 _fcs = player createDiaryRecord ["diary", ["FA3 Enhanced FCS",format ["
 <br/>

--- a/f/fcs/fn_fcsInit.sqf
+++ b/f/fcs/fn_fcsInit.sqf
@@ -33,7 +33,7 @@ if (_vehicle getVariable ["f_var_fcs_hasEH",false]) exitWith { diag_log "FCS: tr
 
 // If the FCS briefing tab hasn't been added already, add it.
 if (isNil "f_var_fcs_briefingDone") then {
-	[] call f_fnc_fcsBriefing;
+	0 spawn f_fnc_fcsBriefing;
 };
 
 // Commander's override action


### PR DESCRIPTION
A small change to scheduling/timing that should let the briefing generator behave better when called from an init field