### PR TITLE
remove ignoreNoDamage mission option

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -2,7 +2,7 @@
 
 // FA3 - Mission Options
 // https://community.bistudio.com/wiki/setMissionOptions
-setMissionOptions createHashMapFromArray [["IgnoreNoDamage", true], ["IgnoreFakeHeadHit", true], ["IgnoreUpsideDownDamage", true]];
+setMissionOptions createHashMapFromArray [["IgnoreFakeHeadHit", true], ["IgnoreUpsideDownDamage", true]];
 
 // ====================================================================================
 


### PR DESCRIPTION
The ignoreNoDamage mission option currently breaks healing. A fix is expected in A3 2.20. In the meantime this setting should be dropped - it's a convenience and no FA3 modules currently rely on it.